### PR TITLE
adding "can now modify cast time" to magie I, II, III and Götterwirken

### DIFF
--- a/dbs/goetterwirken_liturgy.json
+++ b/dbs/goetterwirken_liturgy.json
@@ -119,9 +119,9 @@
   "Bann der göttlichen Gaben": [
     {
       "name": "Liturgiedauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {
@@ -377,9 +377,9 @@
     },
     {
       "name": "Liturgiedauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     }
   ],
@@ -1030,9 +1030,9 @@
   "Goldene Rüstung": [
     {
       "name": "Liturgiedauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {
@@ -1612,9 +1612,9 @@
     },
     {
       "name": "Liturgiedauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {
@@ -2157,9 +2157,9 @@
   "Schlaf": [
     {
       "name": "Liturgiedauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {
@@ -2302,9 +2302,9 @@
     },
     {
       "name": "Liturgiedauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {
@@ -2486,7 +2486,6 @@
     },
     {
       "name": "Mehrere Ziele",
-      "complete": true,
       "complete": true,
       "changes": [
         {"key": "macro.transform", "mode": 2, "value": "multitarget-4AsP_per_target"}

--- a/dbs/magie1_spell.json
+++ b/dbs/magie1_spell.json
@@ -994,9 +994,9 @@
     },
     {
       "name": "Zauberdauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {
@@ -1469,9 +1469,9 @@
   "Heptagramma": [
     {
       "name": "Zauberdauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {
@@ -1515,9 +1515,9 @@
   "Hexagramma": [
     {
       "name": "Zauberdauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {
@@ -2394,9 +2394,9 @@
   "Pentagramma": [
     {
       "name": "Zauberdauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {
@@ -2558,9 +2558,9 @@
   "Regeneratio": [
     {
       "name": "Zauberdauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {

--- a/dbs/magie2_spell.json
+++ b/dbs/magie2_spell.json
@@ -248,9 +248,9 @@
   "Brennender Hass": [
     {
       "name": "Zauberdauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {

--- a/dbs/magie3_spell.json
+++ b/dbs/magie3_spell.json
@@ -441,18 +441,18 @@
     },
     {
       "name": "Zauberdauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     }
   ],
   "Oktagramma": [
     {
       "name": "Zauberdauer modifizierbar",
-      "complete": false,
+      "complete": true,
       "changes": [
-
+        {"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
       ]
     },
     {


### PR DESCRIPTION
adding 
{"key": "system.canChangeCastingTime", "mode": 5, "value": "true"}
at locations where cast time can vary due to an extension. Using the same key for liturgies

this should complete #18 
Again ignoring Götterwirken 2 due to #23
