### PR TITLE
Create Wirseltrank

### DIFF
--- a/macros/Wirseltrank
+++ b/macros/Wirseltrank
@@ -1,0 +1,25 @@
+// Makro
+
+if (!actor) {
+  ui.notifications.error("Kein Akteur gefunden – bitte stelle sicher, dass der Wirseltrank von einem Charakter im Inventar benutzt wird.");
+} else {
+  const roll = await new Roll("1d3").roll({async: true});
+
+  const current = actor.system.status.regeneration.LePTemp ?? 0;
+
+  await actor.update({
+    "system.status.regeneration.LePTemp": current + roll.total
+  });
+}
+
+await actor.applyDamage(2 * -1);
+
+// Effektdauer muss auf 3600 gestellt werden
+// Aktiver Effekt als Platzhalter: {"key": "system.carryModifier", "mode": 2, "value": +1, -1}
+// Makro (Effektende):
+
+{ const roll = await new Roll("1d3").roll({async: true});
+        
+await actor.applyDamage(roll.total*-1);
+        
+}


### PR DESCRIPTION
Wirseltrank-Funktion;
Außerhalb des Makros muss ein Aktiver Effekt als Platzhalter erstellt werden, der eine Stunde lang wirkt und nach Ende das 2. Makro auslöst.