### PR TITLE
Makro für Ruhe Körper und Goblin-Geistheilung

### DIFF
--- a/macros/Goblin-Geistheilung
+++ b/macros/Goblin-Geistheilung
@@ -1,0 +1,9 @@
+  const regenBonus = qs * 2;
+
+  const currentRegen = getProperty(actor.system, "status.regeneration.LePTemp") ?? 0;
+
+  await actor.update({
+    "system.status.regeneration.LePTemp": currentRegen + regenBonus,
+  });
+
+  ui.notifications.info(`${actor.name} erhält ${regenBonus} Punkte zusätzliche Lebensregeneration.`)


### PR DESCRIPTION
Makro für die Automatisierung des Zaubers "Ruhe Körper" und dem in "Winterwacht" hinterlegten Goblinritual "Goblin-Geistheilung"