### PR TITLE
Weissagung (Teil 1)

### DIFF
--- a/macros/Weissagung (Teil 1)
+++ b/macros/Weissagung (Teil 1)
@@ -1,0 +1,55 @@
+// Makro: Weissagung anbieten 
+
+const sourceActor = canvas.tokens.controlled[0]?.actor || game.user.character;
+if (!sourceActor) {
+  ui.notifications.warn("Bitte zuerst deinen Token auswählen oder ein verknüpftes Charakter-Actor besitzen.");
+  return;
+}
+const senderName = sourceActor.name;
+
+const targets = Array.from(game.user.targets);
+if (targets.length !== 1) {
+  ui.notifications.warn("Bitte genau ein Ziel auswählen.");
+  return;
+}
+const targetToken = targets[0];
+const targetActor = targetToken.actor;
+
+const targetUsers = game.users.players.filter(u => targetActor?.testUserPermission(u, "OWNER"));
+if (targetUsers.length === 0) {
+  ui.notifications.warn("Kein Spieler besitzt das gewählte Ziel.");
+  return;
+}
+
+const whisperRecipients = targetUsers.map(u => u.id);
+
+const messageContent = `
+<div style="text-align:center; font-style: italic; margin-bottom: 10px;">
+  ${senderName} möchte dir eine Weissagung machen.
+</div>
+<div style="display:flex; justify-content:center; margin-top: 10px;">
+  <button data-action="runMacro" style="padding:6px 12px; border:1px solid #888; border-radius:5px; cursor:pointer;">
+    Weissagung
+  </button>
+</div>
+`;
+
+const msg = await ChatMessage.create({
+  content: messageContent,
+  whisper: whisperRecipients
+});
+
+Hooks.once("renderChatMessage", async (chatMessage, html) => {
+  if (chatMessage.id !== msg.id) return;
+
+// XXXPLATZHALTERXXX mit dem Verweis auf Weissagung (Teil 2) ersetzen
+
+  html.find('button[data-action="runMacro"]').on('click', async () => {
+    const macro = await fromUuid("XXXPLATZHALTERXXX"); 
+    if (macro) {
+      macro.execute();
+    } else {
+      ui.notifications.error("Makro im Compendium nicht gefunden!");
+    }
+  });
+});


### PR DESCRIPTION
Teil 1 des Weissagungs-Makros:
Der Spieler, welches dieses Makro auslöst schickt dem Spieler des anvisierten Tokens eine Nachricht ob dieser eine Weissagung erhalten möchte.

Die Weissagung selber wird über ein zweites Makro im Kompendium gesteuert. Es ist wichtig hier den Platzhalter mit der Adresse des abgelegten Makros "Weissagung (Teil 2)" zu ersetzen.