### PR TITLE
Wundenbehandlung (+Machtvoller Heiler)

### DIFF
--- a/macros/Wundenbehandlung (+Machtvoller Heiler)
+++ b/macros/Wundenbehandlung (+Machtvoller Heiler)
@@ -1,0 +1,138 @@
+// Prüfung, ob die SF "Machtvoller Heiler" existiert
+const hasPowerfulHealer = actor.items.find(i => i.name === "Machtvoller Heiler");
+let healerBonus = 0;
+
+if (hasPowerfulHealer) {
+  const roll = await new Roll("1d3").roll({ async: true });
+  healerBonus = roll.total;
+  ui.notifications.info(`${actor.name} erhält zusätzlich +${healerBonus} LeP-Regeneration durch Machtvoller Heiler.`);
+}
+
+const dict = {
+  de: {
+    treatWounds: 'Wunden versorgen',
+    treatPain: 'Schmerzen lindern',
+    description: `<b>Wunden versorgen</b>: Alle Ziele erhalten einen Bonus von <b>${qs}${healerBonus > 0 ? ` + ${healerBonus}` : ""}</b> auf die nächste Regeneration.</br><b>Schmerzen lindern</b>: Pro QS kann eine Stufe Schmerz bei allen Zielen gelindert werden.`,
+  },
+  en: {
+    treatWounds: 'Treat Wounds',
+    treatPain: 'Treat Pain',
+    description: `<b>Treat Wounds</b>: All targets receive a bonus of <b>${qs}${healerBonus > 0 ? ` + ${healerBonus}` : ""}</b> on the next regeneration.</br><b>Treat Pain</b>: For each QS, one level of pain can be treated on the targets.`,
+  },
+}[game.i18n.lang == 'de' ? 'de' : 'en'];
+
+class TreatWounds extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.api.ApplicationV2) {
+  constructor(actor, source, qs) {
+    super();
+    this.macroData = {
+      actor: actor,
+      source: source,
+      qs: qs,
+      item,
+      healerBonus: healerBonus
+    };
+  }
+
+  static DEFAULT_OPTIONS = {
+    window: {
+      title: item.name,
+      resizable: true,
+    },
+    position: {
+      width: 500,
+    },
+    classes: ['treat-wounds'],
+    actions: {
+      contentLink: this.openUuid,
+      treatWounds: this._onTreatWounds,
+      treatPain: this._onTreatPain
+    }
+  };
+
+  static PARTS = {
+    main: {
+      template: 'systems/dsa5/templates/macros/treatWounds.hbs',
+    },
+  };
+
+  static async openUuid(ev, target) {
+    const uuid = ev.currentTarget.dataset.uuid;
+    const item = game.items.get(uuid);
+    if (item) {
+      item.sheet.render(true);
+    }
+  }
+
+  updateTargets(html) {
+    const targets = Array.from(game.user.targets);
+    this.targets = targets.map((x) => x.actor);
+    html.find('.targets').html(this.buildAnchors(targets));
+  }
+
+  static async _onTreatPain(event, target) {
+    for (let actor of this.targets) {
+      if (!actor) continue;
+
+      const ef = {
+        name: `${dict.treatPain} (${this.macroData.qs})`,
+        img: 'icons/svg/aura.svg',
+        changes: [
+          {
+            key: 'system.resistances.effects',
+            value: `inpain ${this.macroData.qs}`,
+            mode: 0,
+          },
+        ],
+        duration: {},
+        flags: {
+          dsa5: {
+            description: `${dict.treatPain} (${this.macroData.qs})`,
+          },
+        },
+      };
+      await actor.addCondition(ef);
+    }
+    this.close();
+  }
+
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    const html = $(this.element);
+    html.find('.content-link').on('click', (ev) => this.openUuid(ev));
+  }
+
+  static async _onTreatWounds(event, target) {
+    for (let actor of this.targets) {
+      if (!actor) continue;
+
+      const currentTemp = actor.system.status.regeneration.LePTemp || 0;
+      const bonus = this.macroData.qs + (this.macroData.healerBonus || 0);
+      const newValue = currentTemp + bonus;
+
+      await actor.update({
+        'system.status.regeneration.LePTemp': newValue,
+      });
+    }
+    this.close();
+  }
+
+  buildAnchors(targets) {
+    const res = [];
+    for (const target of targets) {
+      res.push(target.toAnchor().outerHTML);
+    }
+    return res.join(', ');
+  }
+
+  async _prepareContext(options) {
+    const data = await super._prepareContext(options);
+    this.targets = [actor];
+    data.macroData = this.macroData;
+    data.source = this.buildAnchors([args.sourceActor]);
+    data.lang = dict;
+    data.targets = this.buildAnchors(this.targets);
+    return data;
+  }
+}
+
+new TreatWounds(actor, item, qs).render(true);


### PR DESCRIPTION
Modifikation des bereits vorhandenen Makros.

Automatisierung der erweiterten Talentsonderfertigkeiten "Machtvoller Heiler" - der einzige Effekt, der Wundenbehandlung verändert. 

Ebenfalls wurde der Abgleich der aktuellen und des ausgewürfelten temporären Lep-Regenerationswerts, bei dem nur der höhere Wert beibehalten wurde, durch eine Addition zu der temporären Lep-Regeneration ersetzt.
Dies Ermöglich das Zusammenspiel des Makros mit einer Vielzahl an weiteren Effekten, die ebenfalls den temporären Lep-Regenerations-Wert erhöhen.