### PR TITLE
Kräutermischung (Aventurian Compendium II)

### DIFF
--- a/macros/Kräutermischung.js
+++ b/macros/Kräutermischung.js
@@ -136,7 +136,7 @@
         const created = Array.from({ length: itemCount }, () => newItem);
 
         await actor.createEmbeddedDocuments("Item", created);
-        ui.notifications.info(`${actor.name} ${dict.made} ${itemCount} ${dict.itemName}${itemCount > 1 ? (lang === "de" ? "en" : "s") : ""} ${dict.itemMadeSuffix} (QS=${availableQs}).`);
+        ui.notifications.info(`${actor.name} ${dict.made} ${itemCount} ${dict.itemName}${itemCount > 1 ? (lang === "de" ? "en" : "s") : ""} ${dict.itemMadeSuffix}.`);
     }
 
     const tinyBtnStyle = "display: inline-block; padding: 1px 6px; margin: 0 2px; border: 1px solid #968678; background: #e2d8c9; border-radius: 3px; cursor: pointer; font-weight: bold; color: inherit; text-decoration: none; line-height: 1.2;";


### PR DESCRIPTION
Icons:

[fas fa-mortar-pestle](https://fontawesome.com/v5/icons/mortar-pestle)
[fas fa-times](https://fontawesome.com/v4/icon/times)

Automatisiert die SF Kräutermischung (sowie "Weg des Apothekers" als auch "Meisterliche Kräutermischung"):

Öffnet ein Fenster, welches den Skill und seine Bedinungen beschreibt (Kaufen für 5 Silber oder Suchen)

Bei Bestätigen wird eine Probe auf Pflanzenkunde initialiisiert. Ist dieses bestanden wird ein Gegenstand "Kräutermischung" (oder 2 wenn "Weg des Apothekers" vorhanden ist) im Inventar des Auslösers erzeugt. 

Dem erstellten Gegenstand wird ebenso ein aktiver Effekt übergeben, der eine 1d6 würfelprobe auslöst (oder 2 von denen der niedrigere zählt, wenn "Weg des Apothekers" vorhanden ist). Ist der Wert erfolgreich unterwürfelt dann wird die nächste Regenerationsphase um 1  (oder 2 wenn "Meisterliche Kräutermischung" vorhanden ist) erhöht.