### PR TITLE
Vision der Entrückung

### DIFF
--- a/macros/Vision der Entrückung
+++ b/macros/Vision der Entrückung
@@ -1,0 +1,41 @@
+if (!actor) {
+  ui.notifications.error("Kein Actor gefunden – bitte Makro ausführen, während ein Actor ausgewählt ist.");
+  return;
+}
+
+(async () => {
+  // Schicksalspunkt prüfen
+  let currentFate = getProperty(actor.system, "status.fatePoints.value") ?? 0;
+  if (currentFate <= 0) {
+    ui.notifications.warn(`${actor.name} hat keinen Schicksalspunkt zur Verfügung.`);
+    return;
+  }
+
+  // Schicksalspunkt abziehen
+  await actor.update({ "system.status.fatePoints.value": currentFate - 1 });
+
+  // Fertigkeit "Götter & Kulte" suchen
+  const skill = actor.items.find(i => i.type === "skill" && i.name === "Götter & Kulte");
+  if (!skill) {
+    ui.notifications.error(`${actor.name} hat keine Fertigkeit "Götter & Kulte".`);
+    return;
+  }
+
+  // Skill-Test vorbereiten und ausführen
+  const setupData = await actor.setupSkill(skill, {}, actor.sheet.getTokenId());
+  setupData.testData.opposable = false;
+  const res = await actor.basicTest(setupData);
+
+  if (res.result.successLevel > 0) {
+    // Erfolgreiche Probe: 2 Stufen Entrückung hinzufügen
+    if (actor.addCondition) {
+      await actor.addCondition("raptured"); // erste Stufe
+      await actor.addCondition("raptured"); // zweite Stufe
+      ui.notifications.info(`${actor.name} hat die Probe bestanden und erhält 2 Stufen Entrückung.`);
+    } else {
+      ui.notifications.warn("System-Funktion 'addCondition' ist nicht verfügbar.");
+    }
+  } else {
+    ui.notifications.warn(`${actor.name} hat die Probe auf "Götter & Kulte" nicht bestanden.`);
+  }
+})();


### PR DESCRIPTION
Überprüft ob ein Schicksalspunkt vorhanden. Wenn ja, wird ein Schicksalspunkt abgezogen und eine Probe auf Götter und Kulte geworfen. Bei bestehen werdem dem Akteur 2 Stufen Entrückung hinzugefügt.