### PR TITLE
Kleine Trankverdünnung (Aventurian Magic II)

### DIFF
--- a/macros/Kleine_Trankverdünnung.js
+++ b/macros/Kleine_Trankverdünnung.js
@@ -28,7 +28,7 @@
         en: {
             title: "Alchemical Dilution",
             infoHeader: "Alchemical Dilution",
-            infoText: "The caster can dilute an alchemical elixir, creating two elixirs. Each has 3 lower QS. If QS drops to 0 or below, the dilution fails and the elixir becomes unusable.",
+            infoText: "The caster can dilute an alchemical elixir, creating two elixirs. Each has 3 lower QL. If QL drops to 0 or below, the dilution fails and the elixir becomes unusable.",
             dropHint: "Click the box to select or drag an elixir into it.",
             aspCostText: "It costs 4 AsP.",
             dragDropZone: "Click or Drag & Drop",
@@ -42,7 +42,7 @@
             onlyHealingAlchemyError: "Only healing remedies or elixirs can be diluted.",
             success: "The elixir was successfully diluted!",
             fail: "The dilution failed!",
-            qsLabel: "QS"
+            qsLabel: "QL"
         }
     };
 


### PR DESCRIPTION
Icons:

[fas fa-times](https://fontawesome.com/v4/icon/times)
[fas fa-flask](https://fontawesome.com/v4/icon/flask)

Spieler kann per Drag&Drop ein Trank oder Heilmittel (Heiltränke sind aktuell als Heilmittel, nicht als Alchimie getagged) in das Fenster ablegen (QS wird angezeigt). Will es diesen verdünnen, wird immer die Anzahl des Gegenstandes um 1 reduziert und dem kontrollierten Charakter werden 4 AsP abgezogen. Ist die QS des Items höher als "3", werden 2 neue Items mit der QS-3 angelegt. Ist dies nicht der Fall wird weiterhin die Anzahl des Gegenstandes um 1 reduziert.