### PR TITLE
Rachenputzer (Arkane Schmiede und Labore)

### DIFF
--- a/macros/consumable/Rachenputzer (Arkane Schmiede und Labore)
+++ b/macros/consumable/Rachenputzer (Arkane Schmiede und Labore)
@@ -1,0 +1,103 @@
+const target = Array.from(game.user.targets)[0];
+if (!target) {
+  ui.notifications.error("Kein Ziel ausgewählt! Bitte ein Token anvisieren.");
+  return;
+}
+
+const targetActor = target.actor;
+
+// --- 1. Schaden berechnen nach QS ---
+const die = ["1d6", "1d6+2", "2d6", "2d6+2", "2d6+6", "2d6+6"][qs - 1];
+let roll = await new Roll(die).evaluate({async: true});
+const damage = roll.total;
+
+// --- 2. Reichweite je nach QS ---
+const ranges = ["0/3/3", "0/6/6", "0/8/8", "0/12/12", "0/16/16", "0/32/32"];
+const reach = ranges[qs - 1];
+
+// --- 3. Dummy-Angriff vorbereiten ---
+const weaponData = {
+  name: "Odemwaffe",
+  type: "rangeweapon",
+  img: "systems/dsa5/icons/categories/Rangeweapon.webp",
+  system: {
+    damage: {
+      value: `${damage}`, // Schaden aus Schritt 1
+    },
+    reloadTime: {
+      value: 0,
+      progress: 0,
+    },
+    reach: {
+      value: reach, // Reichweite aus Tabelle
+    },
+    ammunitiongroup: {
+      value: "-",
+    },
+    combatskill: {
+      value: "Bögen",
+    },
+    worn: {
+      value: false,
+    },
+    structure: {
+      max: 0,
+      value: 0,
+    },
+    quantity: {
+      value: 1,
+    },
+    price: {
+      value: 0,
+    },
+    weight: {
+      value: 0,
+    },
+    effect: {
+      value: "",
+      attributes: "",
+    },
+  },
+  effects: []
+};
+
+// --- 3a. Brennend-Effekt nur bei QS >= 3 ---
+if (qs >= 3) {
+  weaponData.effects.push({
+    name: "Brennend",
+    type: "",
+    img: "icons/svg/aura.svg",
+    changes: [],
+    duration: { startTime: null, seconds: null, rounds: null },
+    flags: {
+      dsa5: {
+        advancedFunction: 2,
+        args3: `await actor.addCondition("burning");`
+      }
+    },
+    disabled: false,
+    transfer: false
+  });
+}
+
+const weapon = new game.dsa5.entities.Itemdsa5(weaponData);
+
+// --- 4. Dummy-Angriff ausführen ---
+const setupData = await game.dsa5.entities.Itemdsa5.getSubClass(weapon.type).setupDialog(
+  null,
+  { mode: "attack", bypass: true, cheat: true, predefinedResult: [{ val: 2, index: 0 }] },
+  weapon,
+  actor,
+  actor.getActiveTokens()[0]?.id
+);
+
+// --- 4a. Verteidigungsmalus setzen (QS 6 -> 2, sonst 0) ---
+const defenseMalus = (qs === 6) ? 2 : 0;
+setupData.testData.situationalModifiers.push({
+  name: game.i18n.localize("MODS.defenseMalus"),
+  value: defenseMalus,
+  type: "defenseMalus",
+  selected: true,
+});
+
+await actor.basicTest(setupData);


### PR DESCRIPTION
Abhängig von der Qs werden Schadenswerte und Reichweiten abgändert. Ab Qs3 kann man den Status "Brennend" auf das Ziel Übertragen. Ab Qs 6 erleitet das Ziel einen Verteidigungsmalus von "2".

Hyperpotente Wirkung ist noch nicht umgesetzt; Mein Vorschlag: GUI mit der Anweisung, dass der Spieler alle Tokens im Sichtfeld anvisieren soll. Danach auswürfelt welche Tokens getroffen werden.