### PR TITLE
Rächerinnen Lycosas (Schwarze Witwen) (Aventurian Magic II)

### DIFF
--- a/macros/specialability/Rächerinnen_Lycosas.js
+++ b/macros/specialability/Rächerinnen_Lycosas.js
@@ -152,7 +152,7 @@ new Dialog({
         // Neues Step
         const newStep = Math.min(6, oldStep + 1);
 
-        // Menge reduzieren oder Item löschen (wie im „Große Trankverdünnung“-Muster)
+        // Menge reduzieren oder Item löschen
         if (qty > 1) {
           await actor.updateEmbeddedDocuments("Item", [
             { _id: embeddedPoison.id, [dict.qtyPath]: qty - 1 }
@@ -172,7 +172,7 @@ new Dialog({
 
         await actor.createEmbeddedDocuments("Item", [newItemData]);
 
-        // Anzeige aktualisieren: wir zeigen die Stufe des neu angelegten Items
+        // Anzeige aktualisieren
         const created = actor.items.find(i =>
           i.type === "poison" &&
           i.name === embeddedPoison.name &&
@@ -189,7 +189,7 @@ new Dialog({
         const msgHtml = dict.chatSuccess(embeddedPoison.name, oldStep, newStep, aspBefore, aspAfter, aspMax);
         ChatMessage.create({ speaker: ChatMessage.getSpeaker({ actor }), content: msgHtml });
 
-        // Eingebettetes Referenz-Item aktualisieren (zeigt nun auf das neue mit erhöhter Stufe)
+        // Eingebettetes Referenz-Item aktualisieren
         embeddedPoison = created ?? embeddedPoison;
 
         return false; // Dialog offen lassen

--- a/macros/specialability/Rächerinnen_Lycosas.js
+++ b/macros/specialability/Rächerinnen_Lycosas.js
@@ -1,0 +1,281 @@
+// This is a system macro used for automation. It is disfunctional without the proper context.
+
+
+const lang = game.i18n.lang == "de" ? "de" : "en";
+const dict = {
+  de: {
+    title: "Gift verstärken",
+    aspWarn: "Nicht genügend AsP (4 benötigt).",
+    selectGift: "Ziehe ein Gift hierher",
+    giftCategoryLabel: "Gift",
+    currentStep: "Giftstufe",
+    currentAsp: "AsP",
+    strengthen: "Gift verstärken",
+    cancel: "Abbrechen",
+    invalidItem: "Nur Items der Kategorie 'Gift' sind erlaubt.",
+    stepTooHigh: "Nur Gifte mit Stufe 5 oder niedriger sind erlaubt.",
+    noGift: "Kein Gift im Inventar des Actors gefunden. Bitte das Gift aus deinem Inventar ziehen.",
+    stepReadError: "Giftstufe konnte nicht gelesen werden.",
+    aspWithCost: (current, max, cost) => `${current}${typeof max === "number" ? `/${max}` : ""} AsP (Kosten: ${cost})`,
+    chatSuccess: (name, oldStep, newStep, aspBefore, aspAfter, aspMax) =>
+      `<b>${name}</b> verstärkt das Gift: Stufe ${oldStep} → ${newStep}. AsP: ${aspBefore}${typeof aspMax==="number" ? `/${aspMax}`:""} → ${aspAfter}${typeof aspMax==="number" ? `/${aspMax}`:""}.`,
+    aspPath: "system.status.astralenergy.value",
+    aspMaxPath: "system.status.astralenergy.max",
+    stepPath: "system.step.value",
+    qtyPath: "system.quantity.value",
+  },
+  en: {
+    title: "Enhance Poison",
+    aspWarn: "Not enough AsP (requires 4).",
+    selectGift: "Drag a poison here",
+    giftCategoryLabel: "Poison",
+    currentStep: "Poison Level",
+    currentAsp: "AE",
+    strengthen: "Enhance Poison",
+    cancel: "Cancel",
+    invalidItem: "Only items of category 'Poison' are allowed.",
+    stepTooHigh: "Only poisons of Level 5 or lower are allowed.",
+    noGift: "No poison found in the actor's inventory. Please drop it from your inventory.",
+    stepReadError: "Could not read poison step.",
+    aspWithCost: (current, max, cost) => `${current}${typeof max === "number" ? `/${max}` : ""} AE (Cost: ${cost})`,
+    chatSuccess: (name, oldStep, newStep, aspBefore, aspAfter, aspMax) =>
+      `<b>${name}</b> enhances the poison: Step ${oldStep} → ${newStep}. AE: ${aspBefore}${typeof aspMax==="number" ? `/${aspMax}`:""} → ${aspAfter}${typeof aspMax==="number" ? `/${aspMax}`:""}.`,
+    aspPath: "system.status.astralenergy.value",
+    aspMaxPath: "system.status.astralenergy.max",
+    stepPath: "system.step.value",
+    qtyPath: "system.quantity.value",
+  }
+}[lang];
+
+const { getProperty: getProp, setProperty: setProp, duplicate: dup } = foundry.utils;
+const ASP_COST = 4;
+
+
+// Helpers AsP
+function getAsp(actor) {
+  return Number(getProp(actor, dict.aspPath) ?? 0) || 0;
+}
+function getAspMax(actor) {
+  const max = getProp(actor, dict.aspMaxPath);
+  return typeof max === "number" ? max : null;
+}
+function hasEnoughAsp(actor) {
+  return getAsp(actor) >= ASP_COST;
+}
+async function spendAsp(actor, amount = ASP_COST) {
+  const current = getAsp(actor);
+  const newVal = Math.max(0, current - amount);
+  await actor.update({ [dict.aspPath]: newVal });
+}
+
+// Poison helpers
+function readPoisonStep(doc) {
+  const step = getProp(doc, dict.stepPath);
+  const n = Number(step);
+  return Number.isFinite(n) ? n : null;
+}
+function readQuantity(doc) {
+  const q = getProp(doc, dict.qtyPath);
+  const n = Number(q);
+  return Number.isFinite(n) ? n : 1;
+}
+function resolveEmbeddedPoison(sourceItem) {
+  if (sourceItem?.id) {
+    const byId = actor.items.get(sourceItem.id);
+    if (byId?.type?.toLowerCase() === "poison") return byId;
+  }
+  if (sourceItem?.name) {
+    const byName = actor.items.find(i => i.type === "poison" && i.name === sourceItem.name);
+    if (byName) return byName;
+  }
+  return null;
+}
+
+// Vorab AsP prüfen
+if (!hasEnoughAsp(actor)) {
+  ui.notifications.warn(dict.aspWarn);
+  return;
+}
+
+let srcItem = null;            
+let embeddedPoison = null;     
+
+const content = `
+<div style="display:flex; flex-direction:column; gap:8px; max-width:520px;">
+  <div id="error-msg" style="color:#b51c1c; display:none;"></div>
+
+  <div id="drop-zone" style="border:2px dashed #666; border-radius:8px; padding:12px; text-align:center; color:#888;">
+    <div style="margin-bottom:8px;">${dict.selectGift} (${dict.giftCategoryLabel})</div>
+    <img id="gift-img" src="icons/svg/poison.svg" alt="gift" style="width:96px; height:96px; object-fit:contain; margin:auto; display:block;">
+  </div>
+
+  <div class="info" style="display:flex; gap:16px; justify-content:center; font-size:14px;">
+    <div><strong>${dict.currentStep}:</strong> <span id="gift-step">-</span></div>
+    <div><strong>${dict.currentAsp}:</strong> <span id="actor-asp"></span></div>
+  </div>
+</div>
+`;
+
+new Dialog({
+  title: dict.title,
+  content,
+  buttons: {
+    strengthen: {
+      label: dict.strengthen,
+      callback: async (html) => {
+        if (!embeddedPoison) {
+          ui.notifications.warn(dict.noGift);
+          return false;
+        }
+        // AsP erneut prüfen
+        if (!hasEnoughAsp(actor)) {
+          ui.notifications.warn(dict.aspWarn);
+          const aspEl = html.find("#actor-asp")[0];
+          if (aspEl) aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+          return false;
+        }
+
+        // Werte vorab
+        const aspBefore = getAsp(actor);
+        const aspMax = getAspMax(actor);
+        const oldStep = readPoisonStep(embeddedPoison);
+        if (oldStep === null) {
+          ui.notifications.warn(dict.stepReadError);
+          return false;
+        }
+        const qty = readQuantity(embeddedPoison);
+
+        // AsP abziehen
+        await spendAsp(actor, ASP_COST);
+        const aspAfter = getAsp(actor);
+
+        // Neues Step
+        const newStep = Math.min(6, oldStep + 1);
+
+        // Menge reduzieren oder Item löschen (wie im „Große Trankverdünnung“-Muster)
+        if (qty > 1) {
+          await actor.updateEmbeddedDocuments("Item", [
+            { _id: embeddedPoison.id, [dict.qtyPath]: qty - 1 }
+          ]);
+        } else {
+          await actor.deleteEmbeddedDocuments("Item", [embeddedPoison.id]);
+        }
+
+        // Neues Item mit erhöhter Stufe anlegen: dupliziere das eingebettete Item
+        const newItemData = dup(embeddedPoison.toObject());
+        // Entferne _id, damit eine neue Instanz entsteht
+        delete newItemData._id;
+        // Setze Menge 1
+        setProp(newItemData, dict.qtyPath, 1);
+        // Setze die erhöhte Stufe
+        setProp(newItemData, dict.stepPath, newStep);
+
+        await actor.createEmbeddedDocuments("Item", [newItemData]);
+
+        // Anzeige aktualisieren: wir zeigen die Stufe des neu angelegten Items
+        const created = actor.items.find(i =>
+          i.type === "poison" &&
+          i.name === embeddedPoison.name &&
+          readPoisonStep(i) === newStep
+        );
+
+        const stepEl = html.find("#gift-step")[0];
+        if (stepEl) stepEl.textContent = String(readPoisonStep(created) ?? newStep);
+
+        const aspEl = html.find("#actor-asp")[0];
+        if (aspEl) aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+
+        // Chatmeldung
+        const msgHtml = dict.chatSuccess(embeddedPoison.name, oldStep, newStep, aspBefore, aspAfter, aspMax);
+        ChatMessage.create({ speaker: ChatMessage.getSpeaker({ actor }), content: msgHtml });
+
+        // Eingebettetes Referenz-Item aktualisieren (zeigt nun auf das neue mit erhöhter Stufe)
+        embeddedPoison = created ?? embeddedPoison;
+
+        return false; // Dialog offen lassen
+      }
+    },
+    cancel: { label: dict.cancel }
+  },
+  default: "strengthen",
+  render: (html) => {
+    const dropZone = html.find("#drop-zone")[0];
+    const imgEl = html.find("#gift-img")[0];
+    const stepEl = html.find("#gift-step")[0];
+    const aspEl = html.find("#actor-asp")[0];
+    const errorEl = html.find("#error-msg")[0];
+
+    // Initial AsP anzeigen
+    if (aspEl) aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+
+    function showError(msg) {
+      if (!errorEl) return;
+      errorEl.style.display = "block";
+      errorEl.textContent = msg;
+    }
+    function clearError() {
+      if (!errorEl) return;
+      errorEl.style.display = "none";
+      errorEl.textContent = "";
+    }
+    function updateInfo(docForView) {
+      if (imgEl) imgEl.src = docForView?.img || "icons/svg/poison.svg";
+      const s = readPoisonStep(docForView);
+      if (stepEl) stepEl.textContent = s !== null ? String(s) : "-";
+      if (aspEl) aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+    }
+
+    if (!dropZone) return;
+
+    dropZone.ondragover = (ev) => { ev.preventDefault(); dropZone.style.borderColor = "green"; };
+    dropZone.ondragleave = (ev) => { ev.preventDefault(); dropZone.style.borderColor = "#666"; };
+    dropZone.ondrop = async (ev) => {
+      ev.preventDefault();
+      dropZone.style.borderColor = "#666";
+      clearError();
+
+      let raw = ev.dataTransfer?.getData?.("text/plain");
+      if (!raw) { showError(dict.invalidItem); return; }
+      let data;
+      try { data = JSON.parse(raw); } catch { showError(dict.invalidItem); return; }
+
+      // Item laden
+      let itemDoc = null;
+      try {
+        if (data?.type === "Item") {
+          if (typeof data.uuid === "string" && data.uuid.length) {
+            itemDoc = await fromUuid(data.uuid);
+          } else if (data.actorId && data.itemId) {
+            const a = game.actors.get(data.actorId);
+            itemDoc = a?.items?.get(data.itemId) ?? null;
+          }
+        }
+      } catch { itemDoc = null; }
+
+      if (!itemDoc) { showError(dict.invalidItem); return; }
+
+      // Kategorie prüfen: type === "poison"
+      const isPoison = String(itemDoc?.type ?? "").toLowerCase() === "poison";
+      if (!isPoison) { showError(dict.invalidItem); return; }
+
+      // Stufe aus Quelle lesen (zur Anzeige) und prüfen
+      const stepValSrc = readPoisonStep(itemDoc);
+      if (stepValSrc === null) { showError(dict.stepReadError); return; }
+      if (stepValSrc > 5) { showError(dict.stepTooHigh); return; }
+
+      // Eingebettetes Poison im aktuellen actor suchen
+      const embedded = resolveEmbeddedPoison(itemDoc);
+      if (!embedded) {
+        showError(dict.noGift);
+        return;
+      }
+
+      // Auswahl
+      srcItem = itemDoc;
+      embeddedPoison = embedded;
+
+      // Anzeige basierend auf embedded Item aktualisieren
+      updateInfo(embeddedPoison);
+    };
+  }
+}, { width: 520 }).render(true);

--- a/macros/specialability/Rächerinnen_Lycosas.js
+++ b/macros/specialability/Rächerinnen_Lycosas.js
@@ -1,281 +1,367 @@
 // This is a system macro used for automation. It is disfunctional without the proper context.
 
+(async () => {
+  const { getProperty: getProp, setProperty: setProp } = foundry.utils;
+  const { DialogV2 } = foundry.applications.api;
 
-const lang = game.i18n.lang == "de" ? "de" : "en";
-const dict = {
-  de: {
-    title: "Gift verstärken",
-    aspWarn: "Nicht genügend AsP (4 benötigt).",
-    selectGift: "Ziehe ein Gift hierher",
-    giftCategoryLabel: "Gift",
-    currentStep: "Giftstufe",
-    currentAsp: "AsP",
-    strengthen: "Gift verstärken",
-    cancel: "Abbrechen",
-    invalidItem: "Nur Items der Kategorie 'Gift' sind erlaubt.",
-    stepTooHigh: "Nur Gifte mit Stufe 5 oder niedriger sind erlaubt.",
-    noGift: "Kein Gift im Inventar des Actors gefunden. Bitte das Gift aus deinem Inventar ziehen.",
-    stepReadError: "Giftstufe konnte nicht gelesen werden.",
-    aspWithCost: (current, max, cost) => `${current}${typeof max === "number" ? `/${max}` : ""} AsP (Kosten: ${cost})`,
-    chatSuccess: (name, oldStep, newStep, aspBefore, aspAfter, aspMax) =>
-      `<b>${name}</b> verstärkt das Gift: Stufe ${oldStep} → ${newStep}. AsP: ${aspBefore}${typeof aspMax==="number" ? `/${aspMax}`:""} → ${aspAfter}${typeof aspMax==="number" ? `/${aspMax}`:""}.`,
-    aspPath: "system.status.astralenergy.value",
-    aspMaxPath: "system.status.astralenergy.max",
-    stepPath: "system.step.value",
-    qtyPath: "system.quantity.value",
-  },
-  en: {
-    title: "Enhance Poison",
-    aspWarn: "Not enough AsP (requires 4).",
-    selectGift: "Drag a poison here",
-    giftCategoryLabel: "Poison",
-    currentStep: "Poison Level",
-    currentAsp: "AE",
-    strengthen: "Enhance Poison",
-    cancel: "Cancel",
-    invalidItem: "Only items of category 'Poison' are allowed.",
-    stepTooHigh: "Only poisons of Level 5 or lower are allowed.",
-    noGift: "No poison found in the actor's inventory. Please drop it from your inventory.",
-    stepReadError: "Could not read poison step.",
-    aspWithCost: (current, max, cost) => `${current}${typeof max === "number" ? `/${max}` : ""} AE (Cost: ${cost})`,
-    chatSuccess: (name, oldStep, newStep, aspBefore, aspAfter, aspMax) =>
-      `<b>${name}</b> enhances the poison: Step ${oldStep} → ${newStep}. AE: ${aspBefore}${typeof aspMax==="number" ? `/${aspMax}`:""} → ${aspAfter}${typeof aspMax==="number" ? `/${aspMax}`:""}.`,
-    aspPath: "system.status.astralenergy.value",
-    aspMaxPath: "system.status.astralenergy.max",
-    stepPath: "system.step.value",
-    qtyPath: "system.quantity.value",
+  if (!actor) {
+    ui.notifications.warn("Dieses Makro benötigt einen Akteur.");
+    return;
   }
-}[lang];
 
-const { getProperty: getProp, setProperty: setProp, duplicate: dup } = foundry.utils;
-const ASP_COST = 4;
-
-
-// Helpers AsP
-function getAsp(actor) {
-  return Number(getProp(actor, dict.aspPath) ?? 0) || 0;
-}
-function getAspMax(actor) {
-  const max = getProp(actor, dict.aspMaxPath);
-  return typeof max === "number" ? max : null;
-}
-function hasEnoughAsp(actor) {
-  return getAsp(actor) >= ASP_COST;
-}
-async function spendAsp(actor, amount = ASP_COST) {
-  const current = getAsp(actor);
-  const newVal = Math.max(0, current - amount);
-  await actor.update({ [dict.aspPath]: newVal });
-}
-
-// Poison helpers
-function readPoisonStep(doc) {
-  const step = getProp(doc, dict.stepPath);
-  const n = Number(step);
-  return Number.isFinite(n) ? n : null;
-}
-function readQuantity(doc) {
-  const q = getProp(doc, dict.qtyPath);
-  const n = Number(q);
-  return Number.isFinite(n) ? n : 1;
-}
-function resolveEmbeddedPoison(sourceItem) {
-  if (sourceItem?.id) {
-    const byId = actor.items.get(sourceItem.id);
-    if (byId?.type?.toLowerCase() === "poison") return byId;
-  }
-  if (sourceItem?.name) {
-    const byName = actor.items.find(i => i.type === "poison" && i.name === sourceItem.name);
-    if (byName) return byName;
-  }
-  return null;
-}
-
-// Vorab AsP prüfen
-if (!hasEnoughAsp(actor)) {
-  ui.notifications.warn(dict.aspWarn);
-  return;
-}
-
-let srcItem = null;            
-let embeddedPoison = null;     
-
-const content = `
-<div style="display:flex; flex-direction:column; gap:8px; max-width:520px;">
-  <div id="error-msg" style="color:#b51c1c; display:none;"></div>
-
-  <div id="drop-zone" style="border:2px dashed #666; border-radius:8px; padding:12px; text-align:center; color:#888;">
-    <div style="margin-bottom:8px;">${dict.selectGift} (${dict.giftCategoryLabel})</div>
-    <img id="gift-img" src="icons/svg/poison.svg" alt="gift" style="width:96px; height:96px; object-fit:contain; margin:auto; display:block;">
-  </div>
-
-  <div class="info" style="display:flex; gap:16px; justify-content:center; font-size:14px;">
-    <div><strong>${dict.currentStep}:</strong> <span id="gift-step">-</span></div>
-    <div><strong>${dict.currentAsp}:</strong> <span id="actor-asp"></span></div>
-  </div>
-</div>
-`;
-
-new Dialog({
-  title: dict.title,
-  content,
-  buttons: {
-    strengthen: {
-      label: dict.strengthen,
-      callback: async (html) => {
-        if (!embeddedPoison) {
-          ui.notifications.warn(dict.noGift);
-          return false;
-        }
-        // AsP erneut prüfen
-        if (!hasEnoughAsp(actor)) {
-          ui.notifications.warn(dict.aspWarn);
-          const aspEl = html.find("#actor-asp")[0];
-          if (aspEl) aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
-          return false;
-        }
-
-        // Werte vorab
-        const aspBefore = getAsp(actor);
-        const aspMax = getAspMax(actor);
-        const oldStep = readPoisonStep(embeddedPoison);
-        if (oldStep === null) {
-          ui.notifications.warn(dict.stepReadError);
-          return false;
-        }
-        const qty = readQuantity(embeddedPoison);
-
-        // AsP abziehen
-        await spendAsp(actor, ASP_COST);
-        const aspAfter = getAsp(actor);
-
-        // Neues Step
-        const newStep = Math.min(6, oldStep + 1);
-
-        // Menge reduzieren oder Item löschen
-        if (qty > 1) {
-          await actor.updateEmbeddedDocuments("Item", [
-            { _id: embeddedPoison.id, [dict.qtyPath]: qty - 1 }
-          ]);
-        } else {
-          await actor.deleteEmbeddedDocuments("Item", [embeddedPoison.id]);
-        }
-
-        // Neues Item mit erhöhter Stufe anlegen: dupliziere das eingebettete Item
-        const newItemData = dup(embeddedPoison.toObject());
-        // Entferne _id, damit eine neue Instanz entsteht
-        delete newItemData._id;
-        // Setze Menge 1
-        setProp(newItemData, dict.qtyPath, 1);
-        // Setze die erhöhte Stufe
-        setProp(newItemData, dict.stepPath, newStep);
-
-        await actor.createEmbeddedDocuments("Item", [newItemData]);
-
-        // Anzeige aktualisieren
-        const created = actor.items.find(i =>
-          i.type === "poison" &&
-          i.name === embeddedPoison.name &&
-          readPoisonStep(i) === newStep
-        );
-
-        const stepEl = html.find("#gift-step")[0];
-        if (stepEl) stepEl.textContent = String(readPoisonStep(created) ?? newStep);
-
-        const aspEl = html.find("#actor-asp")[0];
-        if (aspEl) aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
-
-        // Chatmeldung
-        const msgHtml = dict.chatSuccess(embeddedPoison.name, oldStep, newStep, aspBefore, aspAfter, aspMax);
-        ChatMessage.create({ speaker: ChatMessage.getSpeaker({ actor }), content: msgHtml });
-
-        // Eingebettetes Referenz-Item aktualisieren
-        embeddedPoison = created ?? embeddedPoison;
-
-        return false; // Dialog offen lassen
-      }
+  const lang = game.i18n.lang == "de" ? "de" : "en";
+  const dict = {
+    de: {
+      title: "Gift verstärken",
+      aspWarn: "Nicht genügend AsP (4 benötigt).",
+      selectGift: "Klicke oder ziehe ein Gift hierher",
+      giftCategoryLabel: "Gift",
+      currentStep: "Giftstufe",
+      currentAsp: "AsP",
+      strengthen: "Gift verstärken",
+      cancel: "Schließen",
+      dragDropZone: "Klicken oder Drag & Drop",
+      emptyList: "Keine passenden Gifte (max. Stufe 5) im Inventar.",
+      invalidItem: "Nur Items der Kategorie 'Gift' sind erlaubt.",
+      stepTooHigh: "Nur Gifte mit Stufe 5 oder niedriger sind erlaubt.",
+      noGift: "Kein Gift ausgewählt.",
+      stepReadError: "Giftstufe konnte nicht gelesen werden.",
+      aspWithCost: (current, max, cost) => `${current}${typeof max === "number" ? `/${max}` : ""} AsP (Kosten: ${cost})`,
+      chatSuccess: (name, oldStep, newStep, aspBefore, aspAfter, aspMax) =>
+        `<b>${name}</b> verstärkt das Gift: Stufe ${oldStep} → ${newStep}. AsP: ${aspBefore}${typeof aspMax === "number" ? `/${aspMax}` : ""} → ${aspAfter}${typeof aspMax === "number" ? `/${aspMax}` : ""}.`,
+      aspPath: "system.status.astralenergy.value",
+      aspMaxPath: "system.status.astralenergy.max",
+      stepPath: "system.step.value",
+      qtyPath: "system.quantity.value",
     },
-    cancel: { label: dict.cancel }
-  },
-  default: "strengthen",
-  render: (html) => {
-    const dropZone = html.find("#drop-zone")[0];
-    const imgEl = html.find("#gift-img")[0];
-    const stepEl = html.find("#gift-step")[0];
-    const aspEl = html.find("#actor-asp")[0];
-    const errorEl = html.find("#error-msg")[0];
-
-    // Initial AsP anzeigen
-    if (aspEl) aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
-
-    function showError(msg) {
-      if (!errorEl) return;
-      errorEl.style.display = "block";
-      errorEl.textContent = msg;
+    en: {
+      title: "Enhance Poison",
+      aspWarn: "Not enough AsP (requires 4).",
+      selectGift: "Click or drag a poison here",
+      giftCategoryLabel: "Poison",
+      currentStep: "Poison Level",
+      currentAsp: "AE",
+      strengthen: "Enhance Poison",
+      cancel: "Close",
+      dragDropZone: "Click or Drag & Drop",
+      emptyList: "No valid poisons (max. Level 5) in inventory.",
+      invalidItem: "Only items of category 'Poison' are allowed.",
+      stepTooHigh: "Only poisons of Level 5 or lower are allowed.",
+      noGift: "No poison selected.",
+      stepReadError: "Could not read poison step.",
+      aspWithCost: (current, max, cost) => `${current}${typeof max === "number" ? `/${max}` : ""} AE (Cost: ${cost})`,
+      chatSuccess: (name, oldStep, newStep, aspBefore, aspAfter, aspMax) =>
+        `<b>${name}</b> enhances the poison: Step ${oldStep} → ${newStep}. AE: ${aspBefore}${typeof aspMax === "number" ? `/${aspMax}` : ""} → ${aspAfter}${typeof aspMax === "number" ? `/${aspMax}` : ""}.`,
+      aspPath: "system.status.astralenergy.value",
+      aspMaxPath: "system.status.astralenergy.max",
+      stepPath: "system.step.value",
+      qtyPath: "system.quantity.value",
     }
-    function clearError() {
-      if (!errorEl) return;
-      errorEl.style.display = "none";
-      errorEl.textContent = "";
+  }[lang];
+
+  const ASP_COST = 4;
+
+  function getAsp(a) { return Number(getProp(a, dict.aspPath) ?? 0) || 0; }
+  function getAspMax(a) { const max = getProp(a, dict.aspMaxPath); return typeof max === "number" ? max : null; }
+  function hasEnoughAsp(a) { return getAsp(a) >= ASP_COST; }
+  async function spendAsp(a, amount = ASP_COST) {
+    const current = getAsp(a);
+    await a.update({ [dict.aspPath]: Math.max(0, current - amount) });
+  }
+  function readPoisonStep(doc) { 
+    const step = getProp(doc, dict.stepPath); 
+    return Number.isFinite(Number(step)) ? Number(step) : null; 
+  }
+  function readQuantity(doc) { 
+    const q = getProp(doc, dict.qtyPath); 
+    return Number.isFinite(Number(q)) ? Number(q) : 1; 
+  }
+  function resolveEmbeddedPoison(sourceItem, a) {
+    if (sourceItem?.id) {
+      const byId = a.items.get(sourceItem.id);
+      if (byId?.type?.toLowerCase() === "poison") return byId;
     }
-    function updateInfo(docForView) {
-      if (imgEl) imgEl.src = docForView?.img || "icons/svg/poison.svg";
-      const s = readPoisonStep(docForView);
-      if (stepEl) stepEl.textContent = s !== null ? String(s) : "-";
-      if (aspEl) aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+    if (sourceItem?.name) {
+      const byName = a.items.find(i => i.type === "poison" && i.name === sourceItem.name);
+      if (byName) return byName;
     }
+    return null;
+  }
 
-    if (!dropZone) return;
+  if (!hasEnoughAsp(actor)) {
+    ui.notifications.warn(dict.aspWarn);
+    return;
+  }
 
-    dropZone.ondragover = (ev) => { ev.preventDefault(); dropZone.style.borderColor = "green"; };
-    dropZone.ondragleave = (ev) => { ev.preventDefault(); dropZone.style.borderColor = "#666"; };
-    dropZone.ondrop = async (ev) => {
-      ev.preventDefault();
-      dropZone.style.borderColor = "#666";
-      clearError();
+  const validItems = actor.items.filter(i => {
+    if (i.type?.toLowerCase() !== "poison") return false;
+    const step = readPoisonStep(i);
+    return step !== null && step <= 5;
+  });
 
-      let raw = ev.dataTransfer?.getData?.("text/plain");
-      if (!raw) { showError(dict.invalidItem); return; }
-      let data;
-      try { data = JSON.parse(raw); } catch { showError(dict.invalidItem); return; }
+  let listItemsHtml = "";
+  if(validItems.length === 0) {
+      listItemsHtml = `<li style="padding: 10px; color: #888; text-align: center; font-style: italic;">${dict.emptyList}</li>`;
+  } else {
+      validItems.forEach(item => {
+          const step = readPoisonStep(item) ?? 1;
+          const qty = readQuantity(item);
+          listItemsHtml += `
+              <li class="poison-option" data-id="${item.id}" style="padding: 6px 10px; cursor: pointer; border-bottom: 1px solid rgba(0,0,0,0.1); display: flex; align-items: center; gap: 10px; transition: background 0.2s;">
+                  <img src="${item.img}" style="width: 28px; height: 28px; border-radius: 3px; border: 1px solid #968678; object-fit: cover;">
+                  <div style="display: flex; flex-direction: column; line-height: 1.1;">
+                      <span style="font-family: 'Signika'; font-weight: bold;">${item.name} <span style="font-weight: normal; color: #555;">(${qty}x)</span></span>
+                      <span style="font-size: 0.85em; color: #444;">${dict.currentStep}: ${step}</span>
+                  </div>
+              </li>`;
+      });
+  }
 
-      // Item laden
-      let itemDoc = null;
-      try {
-        if (data?.type === "Item") {
-          if (typeof data.uuid === "string" && data.uuid.length) {
-            itemDoc = await fromUuid(data.uuid);
-          } else if (data.actorId && data.itemId) {
-            const a = game.actors.get(data.actorId);
-            itemDoc = a?.items?.get(data.itemId) ?? null;
+  class PoisonDialog extends DialogV2 {
+    constructor() {
+      super({
+        window: { title: dict.title, resizable: true },
+        position: { width: 450, height: "auto" },
+        buttons: [
+          {
+            action: "strengthen",
+            label: dict.strengthen,
+            icon: "fas fa-skull-crossbones",
+            callback: async () => await this._onStrengthen()
+          },
+          {
+            action: "cancel",
+            label: dict.cancel,
+            icon: "fas fa-times"
           }
-        }
-      } catch { itemDoc = null; }
+        ],
+        content: `
+          <div class="dsa5" style="display:flex; flex-direction:column; gap:8px; margin-bottom: 15px;">
+            <div id="error-msg" style="color:#b51c1c; display:none; font-weight: bold; text-align: center; font-family: 'Signika';"></div>
 
-      if (!itemDoc) { showError(dict.invalidItem); return; }
+            <div id="drop-zone-container" style="position: relative; margin-top: 5px;">
+              <div id="drop-zone" style="border:2px dashed #968678; border-radius:8px; padding:20px; text-align:center; color:#333; background: rgba(0,0,0,0.05); transition: all 0.2s ease; cursor: pointer; min-height: 80px; display: flex; flex-direction: column; justify-content: center;">
+                <div id="drop-zone-content">
+                  <div style="margin-bottom:0px; font-family: 'Signika'; font-weight: bold; font-size: 1.1em;">
+                    ${dict.selectGift} <span style="font-weight: normal; font-size: 0.9em; opacity: 0.8;">(${dict.giftCategoryLabel})</span>
+                  </div>
+                </div>
+              </div>
+              <ul id="potion-list" style="display: none; position: absolute; top: calc(100% - 2px); left: 0; width: 100%; background: #e2d8c9; border: 1px solid #968678; border-radius: 0 0 5px 5px; padding: 0; margin: 0; list-style: none; max-height: 200px; overflow-y: auto; z-index: 100; box-shadow: 0 4px 6px rgba(0,0,0,0.2);">
+                  ${listItemsHtml}
+              </ul>
+            </div>
 
-      // Kategorie prüfen: type === "poison"
-      const isPoison = String(itemDoc?.type ?? "").toLowerCase() === "poison";
-      if (!isPoison) { showError(dict.invalidItem); return; }
+            <div class="info" style="display:flex; gap:20px; justify-content:center; font-size:15px; margin-top: 10px; font-family: 'Signika'; background: #e2d8c9; padding: 10px; border-radius: 5px; border: 1px solid #968678;">
+              <div><strong>${dict.currentStep}:</strong> <span id="gift-step">-</span></div>
+              <div><strong>${dict.currentAsp}:</strong> <span id="actor-asp"></span></div>
+            </div>
+          </div>
+        `
+      });
+      this.embeddedPoison = null;
+    }
 
-      // Stufe aus Quelle lesen (zur Anzeige) und prüfen
-      const stepValSrc = readPoisonStep(itemDoc);
-      if (stepValSrc === null) { showError(dict.stepReadError); return; }
-      if (stepValSrc > 5) { showError(dict.stepTooHigh); return; }
+    _onRender(context, options) {
+      super._onRender(context, options);
+      const html = this.element;
+      if (!html) return;
 
-      // Eingebettetes Poison im aktuellen actor suchen
-      const embedded = resolveEmbeddedPoison(itemDoc);
-      if (!embedded) {
-        showError(dict.noGift);
+      this.dropZone = html.querySelector("#drop-zone");
+      this.dropZoneContent = html.querySelector("#drop-zone-content");
+      this.potionList = html.querySelector("#potion-list");
+      this.potionOptions = html.querySelectorAll(".poison-option");
+      this.stepEl = html.querySelector("#gift-step");
+      this.aspEl = html.querySelector("#actor-asp");
+      this.errorEl = html.querySelector("#error-msg");
+      
+      this.strengthenBtn = html.querySelector('button[data-action="strengthen"]');
+      if (this.strengthenBtn) {
+          this.strengthenBtn.disabled = true;
+      }
+
+      if (this.aspEl) this.aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+
+      this.dropZone.addEventListener("click", (ev) => {
+          if (this.embeddedPoison) return;
+          this.potionList.style.display = this.potionList.style.display === "none" ? "block" : "none";
+          this.clearError();
+      });
+
+      this.dropZone.addEventListener("contextmenu", (ev) => {
+          ev.preventDefault();
+          this.embeddedPoison = null;
+          this.potionList.style.display = "none";
+          this.updateInfo();
+          this.clearError();
+      });
+
+
+      this.potionOptions.forEach(opt => {
+          opt.addEventListener("mouseenter", () => opt.style.background = "rgba(0,0,0,0.1)");
+          opt.addEventListener("mouseleave", () => opt.style.background = "transparent");
+          
+          opt.addEventListener("click", (ev) => {
+              ev.stopPropagation();
+              const itemId = opt.dataset.id;
+              this.embeddedPoison = actor.items.get(itemId);
+              this.potionList.style.display = "none";
+              this.updateInfo();
+          });
+      });
+
+      html.addEventListener("click", (ev) => {
+          if (!ev.target.closest("#drop-zone-container")) {
+              this.potionList.style.display = "none";
+          }
+      });
+
+      this.dropZone.addEventListener("dragover", (ev) => { 
+        ev.preventDefault(); 
+        this.dropZone.style.borderColor = "#6b944d"; 
+        this.dropZone.style.background = "rgba(107, 148, 77, 0.1)"; 
+      });
+      
+      this.dropZone.addEventListener("dragleave", (ev) => { 
+        ev.preventDefault(); 
+        this.dropZone.style.borderColor = "#968678"; 
+        this.dropZone.style.background = "rgba(0,0,0,0.05)"; 
+      });
+      
+      this.dropZone.addEventListener("drop", async (ev) => {
+        ev.preventDefault();
+        this.dropZone.style.borderColor = "#968678";
+        this.dropZone.style.background = "rgba(0,0,0,0.05)";
+        this.potionList.style.display = "none";
+        this.clearError();
+
+        let raw = ev.dataTransfer?.getData?.("text/plain");
+        if (!raw) return this.showError(dict.invalidItem);
+        
+        let data;
+        try { data = JSON.parse(raw); } catch { return this.showError(dict.invalidItem); }
+
+        let itemDoc = null;
+        try {
+          if (data?.type === "Item") {
+            if (typeof data.uuid === "string" && data.uuid.length) {
+              itemDoc = await fromUuid(data.uuid);
+            } else if (data.actorId && data.itemId) {
+              const a = game.actors.get(data.actorId);
+              itemDoc = a?.items?.get(data.itemId) ?? null;
+            }
+          }
+        } catch { itemDoc = null; }
+
+        if (!itemDoc) return this.showError(dict.invalidItem);
+
+        const isPoison = String(itemDoc?.type ?? "").toLowerCase() === "poison";
+        if (!isPoison) return this.showError(dict.invalidItem);
+
+        const stepValSrc = readPoisonStep(itemDoc);
+        if (stepValSrc === null) return this.showError(dict.stepReadError);
+        if (stepValSrc > 5) return this.showError(dict.stepTooHigh);
+
+        const embedded = resolveEmbeddedPoison(itemDoc, actor);
+        if (!embedded) return this.showError(dict.noGift);
+
+        this.embeddedPoison = embedded;
+        this.updateInfo();
+      });
+    }
+
+    showError(msg) {
+      if (this.errorEl) {
+        this.errorEl.style.display = "block";
+        this.errorEl.textContent = msg;
+      }
+      if (this.strengthenBtn) this.strengthenBtn.disabled = true;
+    }
+
+    clearError() {
+      if (this.errorEl) {
+        this.errorEl.style.display = "none";
+        this.errorEl.textContent = "";
+      }
+    }
+
+    updateInfo() {
+      if (!this.embeddedPoison) {
+        this.dropZoneContent.innerHTML = `
+          <div style="margin-bottom:0px; font-family: 'Signika'; font-weight: bold; font-size: 1.1em;">
+            ${dict.selectGift} <span style="font-weight: normal; font-size: 0.9em; opacity: 0.8;">(${dict.giftCategoryLabel})</span>
+          </div>
+        `;
+        this.dropZone.style.borderStyle = "dashed";
+        if (this.stepEl) this.stepEl.textContent = "-";
+        if (this.aspEl) this.aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+        if (this.strengthenBtn) this.strengthenBtn.disabled = true;
         return;
       }
 
-      // Auswahl
-      srcItem = itemDoc;
-      embeddedPoison = embedded;
+      const s = readPoisonStep(this.embeddedPoison);
+      this.dropZoneContent.innerHTML = `
+        <img src="${this.embeddedPoison.img}" style="width: 70px; height: 70px; object-fit: cover; border: 1px solid #968678; border-radius: 3px; display: block; margin: 0 auto 10px auto; box-shadow: 0 2px 4px rgba(0,0,0,0.3);">
+        <b style="font-family: 'Signika'; font-size: 1.1em;">${this.embeddedPoison.name}</b><br>
+        <div style="font-size: 0.85em; opacity: 0.7; margin-top: 5px;">(Rechtsklick zum Entfernen)</div>
+      `;
+      this.dropZone.style.borderStyle = "solid";
 
-      // Anzeige basierend auf embedded Item aktualisieren
-      updateInfo(embeddedPoison);
-    };
+      if (this.stepEl) this.stepEl.textContent = s !== null ? String(s) : "-";
+      if (this.aspEl) this.aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+      
+      if (this.strengthenBtn) this.strengthenBtn.disabled = false;
+    }
+
+    async _onStrengthen() {
+      if (!this.embeddedPoison) {
+        ui.notifications.warn(dict.noGift);
+        return;
+      }
+
+      if (!hasEnoughAsp(actor)) {
+        ui.notifications.warn(dict.aspWarn);
+        if (this.aspEl) this.aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+        return;
+      }
+
+      const aspBefore = getAsp(actor);
+      const aspMax = getAspMax(actor);
+      const oldStep = readPoisonStep(this.embeddedPoison);
+      if (oldStep === null) return ui.notifications.warn(dict.stepReadError);
+      
+      const qty = readQuantity(this.embeddedPoison);
+
+      await spendAsp(actor, ASP_COST);
+      const aspAfter = getAsp(actor);
+
+      const newStep = Math.min(6, oldStep + 1);
+
+      if (qty > 1) {
+        await actor.updateEmbeddedDocuments("Item", [{ _id: this.embeddedPoison.id, [dict.qtyPath]: qty - 1 }]);
+      } else {
+        await actor.deleteEmbeddedDocuments("Item", [this.embeddedPoison.id]);
+      }
+
+      const newItemData = this.embeddedPoison.toObject();
+      delete newItemData._id;
+      setProp(newItemData, dict.qtyPath, 1);
+      setProp(newItemData, dict.stepPath, newStep);
+
+      const createdDocs = await actor.createEmbeddedDocuments("Item", [newItemData]);
+      const created = createdDocs[0];
+
+      if (this.stepEl) this.stepEl.textContent = String(readPoisonStep(created) ?? newStep);
+      if (this.aspEl) this.aspEl.textContent = dict.aspWithCost(getAsp(actor), getAspMax(actor), ASP_COST);
+
+      const msgHtml = dict.chatSuccess(actor.name, oldStep, newStep, aspBefore, aspAfter, aspMax);
+      ChatMessage.create({ speaker: ChatMessage.getSpeaker({ actor }), content: msgHtml });
+
+      this.embeddedPoison = created;
+      this.updateInfo();
+    }
   }
-}, { width: 520 }).render(true);
+
+  new PoisonDialog().render(true);
+
+})();


### PR DESCRIPTION
Verwendete Icons:

[fas fa-skull-crossbones](https://fontawesome.com/icons/skull-crossbones)
[fas fa-times](https://fontawesome.com/v4/icon/times)


Überprüft ob genügen AsP vorhanden sind
Dra&Drop - Überprüft ob Item ein Gift ist und Stufe 5 oder weniger ist Giftlevel und aktuelles AsP-Level werden angegeben. Bei Klick auf "Gift verstärken" werden Asp nochmals überprüft und abgezogen. Itemanzahl wird um 1 verringert oder gelöscht. Neues Item mit Giftlevel +1 wird angelegt.