### PR TITLE
Arcane Meditation (Aventurian Magic I)

### DIFF
--- a/macros/specialability/Arcane_Meditation.js
+++ b/macros/specialability/Arcane_Meditation.js
@@ -1,0 +1,216 @@
+// This is a system macro used for automation. It is disfunctional without the proper context.
+
+const lang = game.i18n.lang == "de" ? "de" : "en";
+const dict = {
+  de: {
+    title: "Astrale Meditation",
+    talentLabel: "Selbstbeherrschung (Störungen ignorieren)",
+    skillBase: "Selbstbeherrschung",
+    promptMax: "Du kannst maximal {max} Lebenspunkte in Astralenergie umwandeln.",
+    inputLabel: "LeP in AsP umwandeln",
+    convert: "Lebensenergie umwandeln",
+    cancel: "Abbrechen",
+    checkStart: "Probe auf Selbstbeherrschung wird gewürfelt...",
+    checkFailed: "Probe nicht bestanden. Keine Umwandlung möglich.",
+    convertedMsg: "Es wurden {amount} LeP in AsP umgewandelt.",
+    postLoss: (loss, name) => `Zusätzlich verliert ${name} ${loss} LeP (1W3).`,
+    aePath: "system.status.astralenergy.value",
+    aeMaxPath: "system.status.astralenergy.max",
+    lpPath: "system.status.wounds.value",
+    lpMaxPath: "system.status.wounds.max",
+    guiText: "Eine der bekanntesten Techniken erfahrener Zauberer ist die Astrale Meditation. Durch sie kann ein Zauberkundiger seine Lebenskraft in astrale Energie umwandeln. Regel: Der Zauberer ist durch die Astrale Meditation in der Lage, LeP im Verhältnis 1 zu 1 in AsP umzuwandeln. Er muss sich dazu in stiller Umgebung aufhalten (z. B. in einem abgeschiedenen Waldstück oder einem ruhigen Zimmer), eine mindestens 5 Minuten andauernde Meditation durchführen und eine Probe auf Selbstbeherrschung (Störungen ignorieren) bestehen. Er kann maximal QS x3 LeP in AsP umwandeln. Allerdings verliert er am Ende der Meditation zusätzlich 1W3 LeP und er kann die nächsten 24 Stunden keine weitere Astrale Meditation durchführen – egal ob die Meditation erfolgreich war oder nicht.",
+    noToken: "Kein verknüpfter Token des Actors gefunden. Bitte Token auf der Szene verknüpfen.",
+    overMax: (max) => `Eingabe überschreitet das Maximum von ${max}.`,
+    notEnoughLP: "Nicht genügend LeP vorhanden.",
+  },
+  en: {
+    title: "Arcane Meditation",
+    talentLabel: "Self-Control (Ignore Distractions)",
+    skillBase: "Self-Control",
+    promptMax: "You can convert a maximum of {max} Life Points into Astral Energy.",
+    inputLabel: "Convert LP to AE",
+    convert: "Convert Life Energy",
+    cancel: "Cancel",
+    checkStart: "Rolling Self-Control check...",
+    checkFailed: "Check failed. No conversion possible.",
+    convertedMsg: "{amount} LP have been converted to AE.",
+    postLoss: (loss, name) => `Additionally, ${name} loses ${loss} LP (1D3).`,
+    aePath: "system.status.astralenergy.value",
+    aeMaxPath: "system.status.astralenergy.max",
+    lpPath: "system.status.wounds.value",
+    lpMaxPath: "system.status.wounds.max",
+    guiText: "A spellcaster with Arcane Meditation can convert LP into AE. The caster must be in a quiet location (such as in a remote part of the forest, or a quiet room), meditate for at least 5 minutes, and make a Self-Control (Ignore Distractions) check. This converts a maximum of QL x 3 LP to AE. At the end of the meditation period, the caster loses an additional 1D6 LP and will not recover any LP or AE for 24h during any regeneration phases, whether the Arcane Meditation succeeded or not.",
+    noToken: "No linked token of the actor found. Please link a token on the scene.",
+    overMax: (max) => `Input exceeds the maximum of ${max}.`,
+    notEnoughLP: "Not enough LP available.",
+  }
+}[lang];
+
+const gp = foundry.utils.getProperty;
+const sp = foundry.utils.setProperty;
+
+if (!actor) { ui.notifications.error(lang === "de" ? "Kein Actor vorhanden." : "No actor available."); return; }
+
+// Skill finden
+const skill = actor.items.find(x => x.type === "skill" && x.name === dict.skillBase);
+if (!skill) { ui.notifications.warn(`${dict.talentLabel} nicht gefunden.`); return; }
+
+// Probe
+const setupData = await actor.setupSkill(skill, { subtitle: ` (${dict.talentLabel})` }, actor.sheet?.getTokenId?.());
+sp(setupData, "testData.opposable", false);
+ui.notifications.info(dict.checkStart);
+const res = await actor.basicTest(setupData);
+const qs = Number(gp(res, "result.qualityStep")) || 0;
+this.automatedAnimation?.(gp(res, "result.successLevel"));
+if (qs <= 0) { ui.notifications.warn(dict.checkFailed); return; }
+
+const maxConvert = qs * 3;
+const actorName = actor.name ?? (lang === "de" ? "der Charakter" : "the character");
+
+// GUI
+const infoText = dict.guiText;
+const maxLine = dict.promptMax.replace("{max}", String(maxConvert));
+const content = `
+<div style="display:flex; flex-direction:column;">
+  <div style="white-space:pre-wrap; font-size:0.95rem; line-height:1.25rem; margin-bottom:0.375rem;">
+    ${infoText}
+  </div>
+  <div style="font-weight:600; margin-bottom:0.375rem;">
+    ${maxLine}
+  </div>
+  <div style="display:flex; align-items:center; gap:0.5rem; margin-bottom:1.25rem;">
+    <label style="min-width:220px;">${dict.inputLabel}</label>
+    <input id="lepInput" type="number" min="0" step="1" value="${maxConvert}" style="width:120px;"/>
+  </div>
+</div>
+`;
+
+// Kernlogik: direkte Updates via actor.update (möglich da eigener Actor)
+async function doConversion(html, maxLimit, disableBtn) {
+  const inputEl = html.find("#lepInput")[0];
+  const rawVal = Number(inputEl?.value ?? 0);
+  const amount = Math.floor(rawVal);
+
+
+  if (amount > maxLimit) {
+    if (disableBtn) {
+      disableBtn.disabled = true;
+      disableBtn.classList.add("disabled");
+    }
+    ui.notifications.warn(dict.overMax(maxLimit));
+    return false;
+  } else {
+    if (disableBtn) {
+      disableBtn.disabled = false;
+      disableBtn.classList.remove("disabled");
+    }
+  }
+
+  // Werte lesen
+  const currentLP = Number(gp(actor, dict.lpPath)) || 0;
+  const currentAE = Number(gp(actor, dict.aePath)) || 0;
+  const maxAE = Number(gp(actor, dict.aeMaxPath)) || 0;
+
+  // LP verfügbar?
+  if (currentLP < amount) {
+    ui.notifications.error(dict.notEnoughLP);
+    return false;
+  }
+
+  // LP -> AE, AE deckeln
+  const aeToAdd = Math.min(amount, Math.max(0, maxAE - currentAE));
+  const newAE = currentAE + aeToAdd;
+  const newLP = Math.max(0, currentLP - amount);
+
+  // Update des eigenen Actors
+  await actor.update({
+    [dict.lpPath]: newLP,
+    [dict.aePath]: newAE
+  });
+
+  // Chat: Umwandlung
+  ChatMessage.create({
+    speaker: ChatMessage.getSpeaker({ actor }),
+    content: dict.convertedMsg.replace("{amount}", String(aeToAdd))
+  });
+
+  // 1W3 LeP Verlust – evaluieren
+  let loss = 1;
+  try {
+    const lossRoll = new Roll("1d3").evaluateSync();
+    loss = Number(lossRoll.total) || 1;
+  } catch (err) {
+    const lossRoll = new Roll("1d3");
+    await lossRoll.toMessage({ speaker: ChatMessage.getSpeaker({ actor }), flavor: lang === "de" ? "1W3 LeP Verlust" : "1D3 LP loss" });
+    loss = Number(lossRoll.total) || 1;
+  }
+
+  // Verlust anwenden
+  const lpAfterConv = Number(gp(actor, dict.lpPath)) || newLP;
+  const lpAfterLoss = Math.max(0, lpAfterConv - loss);
+
+  await actor.update({
+    [dict.lpPath]: lpAfterLoss
+  });
+
+  // Abschlussmeldung
+  ChatMessage.create({
+    speaker: ChatMessage.getSpeaker({ actor }),
+    content: dict.postLoss(loss, actorName)
+  });
+
+  return true;
+}
+
+let dialogRef = null;
+
+dialogRef = new Dialog({
+  title: dict.title,
+  content,
+  buttons: {
+    convert: {
+      label: dict.convert,
+      callback: async (html) => {
+        // Den Button-Node aus dem Dialog holen, um ihn bei Over-Max zu deaktivieren
+        const btn = dialogRef.element?.find('button[data-button="convert"]')?.get(0);
+        return await doConversion(html, maxConvert, btn);
+      }
+    },
+    cancel: { label: dict.cancel }
+  },
+  default: "convert",
+  render: (html) => {
+    const inputEl = html.find("#lepInput")[0];
+    const btn = dialogRef?.element?.find('button[data-button="convert"]')?.get(0);
+
+    // Enter bestätigt die Eingabe
+    if (inputEl) {
+      inputEl.addEventListener("keydown", async (ev) => {
+        if (ev.key === "Enter") {
+          ev.preventDefault();
+          await doConversion(html, maxConvert, btn);
+        }
+      });
+
+      // Live-Validierung: Button bei Over-Max visuell deaktivieren
+      inputEl.addEventListener("input", () => {
+        const val = Math.floor(Number(inputEl.value ?? 0));
+        if (btn) {
+          if (val > maxConvert) {
+            btn.disabled = true;
+            btn.classList.add("disabled");
+          } else {
+            btn.disabled = false;
+            btn.classList.remove("disabled");
+          }
+        }
+      });
+
+      
+      const initialVal = Math.floor(Number(inputEl.value ?? 0));
+      if (btn) {
+        btn.disabled = initialVal > maxConvert;
+        btn.classList.toggle("disabled", initialVal > maxConvert);
+      }
+    }
+  }

--- a/macros/specialability/Arcane_Meditation.js
+++ b/macros/specialability/Arcane_Meditation.js
@@ -4,20 +4,15 @@ const lang = game.i18n.lang == "de" ? "de" : "en";
 const dict = {
   de: {
     title: "Astrale Meditation",
-    talentLabel: "Selbstbeherrschung (Störungen ignorieren)",
+    talentLabel: "Selbstbeherrschung",
     skillBase: "Selbstbeherrschung",
     promptMax: "Du kannst maximal {max} Lebenspunkte in Astralenergie umwandeln.",
     inputLabel: "LeP in AsP umwandeln",
     convert: "Lebensenergie umwandeln",
     cancel: "Abbrechen",
-    checkStart: "Probe auf Selbstbeherrschung wird gewürfelt...",
     checkFailed: "Probe nicht bestanden. Keine Umwandlung möglich.",
     convertedMsg: "Es wurden {amount} LeP in AsP umgewandelt.",
     postLoss: (loss, name) => `Zusätzlich verliert ${name} ${loss} LeP (1W3).`,
-    aePath: "system.status.astralenergy.value",
-    aeMaxPath: "system.status.astralenergy.max",
-    lpPath: "system.status.wounds.value",
-    lpMaxPath: "system.status.wounds.max",
     guiText: "Eine der bekanntesten Techniken erfahrener Zauberer ist die Astrale Meditation. Durch sie kann ein Zauberkundiger seine Lebenskraft in astrale Energie umwandeln. Regel: Der Zauberer ist durch die Astrale Meditation in der Lage, LeP im Verhältnis 1 zu 1 in AsP umzuwandeln. Er muss sich dazu in stiller Umgebung aufhalten (z. B. in einem abgeschiedenen Waldstück oder einem ruhigen Zimmer), eine mindestens 5 Minuten andauernde Meditation durchführen und eine Probe auf Selbstbeherrschung (Störungen ignorieren) bestehen. Er kann maximal QS x3 LeP in AsP umwandeln. Allerdings verliert er am Ende der Meditation zusätzlich 1W3 LeP und er kann die nächsten 24 Stunden keine weitere Astrale Meditation durchführen – egal ob die Meditation erfolgreich war oder nicht.",
     noToken: "Kein verknüpfter Token des Actors gefunden. Bitte Token auf der Szene verknüpfen.",
     overMax: (max) => `Eingabe überschreitet das Maximum von ${max}.`,
@@ -25,20 +20,15 @@ const dict = {
   },
   en: {
     title: "Arcane Meditation",
-    talentLabel: "Self-Control (Ignore Distractions)",
+    talentLabel: "Self-Control",
     skillBase: "Self-Control",
     promptMax: "You can convert a maximum of {max} Life Points into Astral Energy.",
     inputLabel: "Convert LP to AE",
     convert: "Convert Life Energy",
     cancel: "Cancel",
-    checkStart: "Rolling Self-Control check...",
     checkFailed: "Check failed. No conversion possible.",
     convertedMsg: "{amount} LP have been converted to AE.",
     postLoss: (loss, name) => `Additionally, ${name} loses ${loss} LP (1D3).`,
-    aePath: "system.status.astralenergy.value",
-    aeMaxPath: "system.status.astralenergy.max",
-    lpPath: "system.status.wounds.value",
-    lpMaxPath: "system.status.wounds.max",
     guiText: "A spellcaster with Arcane Meditation can convert LP into AE. The caster must be in a quiet location (such as in a remote part of the forest, or a quiet room), meditate for at least 5 minutes, and make a Self-Control (Ignore Distractions) check. This converts a maximum of QL x 3 LP to AE. At the end of the meditation period, the caster loses an additional 1D6 LP and will not recover any LP or AE for 24h during any regeneration phases, whether the Arcane Meditation succeeded or not.",
     noToken: "No linked token of the actor found. Please link a token on the scene.",
     overMax: (max) => `Input exceeds the maximum of ${max}.`,
@@ -46,171 +36,178 @@ const dict = {
   }
 }[lang];
 
+if (!actor) { ui.notifications.error(lang === "de" ? "Kein Actor vorhanden." : "No actor available."); return; }
+
 const gp = foundry.utils.getProperty;
 const sp = foundry.utils.setProperty;
 
-if (!actor) { ui.notifications.error(lang === "de" ? "Kein Actor vorhanden." : "No actor available."); return; }
+const AE_PATH = "system.status.astralenergy.value";
+const AE_MAX_PATH = "system.status.astralenergy.max";
+const LP_PATH = "system.status.wounds.value";
+const LP_MAX_PATH = "system.status.wounds.max";
 
-// Skill finden
 const skill = actor.items.find(x => x.type === "skill" && x.name === dict.skillBase);
-if (!skill) { ui.notifications.warn(`${dict.talentLabel} nicht gefunden.`); return; }
+if (!skill) { ui.notifications.warn(`Talent "${dict.skillBase}" nicht gefunden.`); return; }
 
-// Probe
 const setupData = await actor.setupSkill(skill, { subtitle: ` (${dict.talentLabel})` }, actor.sheet?.getTokenId?.());
 sp(setupData, "testData.opposable", false);
-ui.notifications.info(dict.checkStart);
 const res = await actor.basicTest(setupData);
 const qs = Number(gp(res, "result.qualityStep")) || 0;
-this.automatedAnimation?.(gp(res, "result.successLevel"));
-if (qs <= 0) { ui.notifications.warn(dict.checkFailed); return; }
+
+if (qs <= 0) { 
+    ui.notifications.warn(dict.checkFailed); 
+    return; 
+}
 
 const maxConvert = qs * 3;
 const actorName = actor.name ?? (lang === "de" ? "der Charakter" : "the character");
 
-// GUI
+const lepLabel = game.i18n.localize("LEP") || "Lebenspunkte";
+const aspLabel = game.i18n.localize("ASP") || "Astralpunkte";
+
+const currentLP = Number(gp(actor, LP_PATH)) || 0;
+const maxLP = Number(gp(actor, LP_MAX_PATH)) || 0;
+const currentAE = Number(gp(actor, AE_PATH)) || 0;
+const maxAE = Number(gp(actor, AE_MAX_PATH)) || 0;
+
+const styleId = "arcane-meditation-styles";
+if (!document.getElementById(styleId)) {
+    document.head.insertAdjacentHTML("beforeend", `
+        <style id="${styleId}">
+            #dsa-arcanemeditation-container { display: flex; flex-direction: column; }
+            #dsa-arcanemeditation-container .info-text { font-size: 0.95rem; line-height: 1.25rem; margin-bottom: 10px; font-style: italic; }
+            #dsa-arcanemeditation-container .max-line { font-weight: bold; margin-bottom: 10px; text-align: center; }
+            #dsa-arcanemeditation-container .status-bars { 
+                display: flex; 
+                flex-direction: column; 
+                align-items: center; 
+                gap: 5px; 
+                margin-bottom: 15px; 
+                font-weight: bold; 
+                padding: 10px 0; 
+                border-top: 1px solid #7a7971; 
+                border-bottom: 1px solid #7a7971; 
+                background: rgba(0,0,0,0.03); 
+                font-size: 1.1em; 
+            }
+            #dsa-arcanemeditation-container .input-group { display: flex; align-items: center; justify-content: center; gap: 10px; margin-bottom: 15px; }
+            #dsa-arcanemeditation-container .lep-input { width: 80px; text-align: center; font-weight: bold; }
+        </style>
+    `);
+}
+
 const infoText = dict.guiText;
 const maxLine = dict.promptMax.replace("{max}", String(maxConvert));
+const inputMax = Math.min(currentLP, maxConvert);
+
 const content = `
-<div style="display:flex; flex-direction:column;">
-  <div style="white-space:pre-wrap; font-size:0.95rem; line-height:1.25rem; margin-bottom:0.375rem;">
+<div id="dsa-arcanemeditation-container">
+  <div class="info-text">
     ${infoText}
   </div>
-  <div style="font-weight:600; margin-bottom:0.375rem;">
+  <hr>
+  <div class="max-line">
     ${maxLine}
   </div>
-  <div style="display:flex; align-items:center; gap:0.5rem; margin-bottom:1.25rem;">
-    <label style="min-width:220px;">${dict.inputLabel}</label>
-    <input id="lepInput" type="number" min="0" step="1" value="${maxConvert}" style="width:120px;"/>
+  
+  <div class="status-bars">
+    <span>${lepLabel}: ${currentLP} / ${maxLP}</span>
+    <span>${aspLabel}: ${currentAE} / ${maxAE}</span>
+  </div>
+
+  <div class="input-group">
+    <label for="lepInput">${dict.inputLabel}:</label>
+    <input id="lepInput" name="lepInput" class="lep-input" type="number" min="0" step="1" max="${inputMax}" value="${inputMax}" autofocus />
   </div>
 </div>
 `;
 
-// Kernlogik: direkte Updates via actor.update (möglich da eigener Actor)
-async function doConversion(html, maxLimit, disableBtn) {
-  const inputEl = html.find("#lepInput")[0];
-  const rawVal = Number(inputEl?.value ?? 0);
-  const amount = Math.floor(rawVal);
+async function doConversion(rawVal, maxLimit) {
+    const amount = Math.floor(Number(rawVal));
+    if (amount <= 0) return;
 
-
-  if (amount > maxLimit) {
-    if (disableBtn) {
-      disableBtn.disabled = true;
-      disableBtn.classList.add("disabled");
+    if (amount > maxLimit) {
+        ui.notifications.warn(dict.overMax(maxLimit));
+        return;
     }
-    ui.notifications.warn(dict.overMax(maxLimit));
-    return false;
-  } else {
-    if (disableBtn) {
-      disableBtn.disabled = false;
-      disableBtn.classList.remove("disabled");
+
+    const currentLP = Number(gp(actor, LP_PATH)) || 0;
+    const currentAE = Number(gp(actor, AE_PATH)) || 0;
+    const maxAE = Number(gp(actor, AE_MAX_PATH)) || 0;
+
+    if (currentLP < amount) {
+        ui.notifications.error(dict.notEnoughLP);
+        return false;
     }
-  }
 
-  // Werte lesen
-  const currentLP = Number(gp(actor, dict.lpPath)) || 0;
-  const currentAE = Number(gp(actor, dict.aePath)) || 0;
-  const maxAE = Number(gp(actor, dict.aeMaxPath)) || 0;
+    const aeToAdd = Math.min(amount, Math.max(0, maxAE - currentAE));
+    const newAE = currentAE + aeToAdd;
+    const newLP = Math.max(0, currentLP - amount);
 
-  // LP verfügbar?
-  if (currentLP < amount) {
-    ui.notifications.error(dict.notEnoughLP);
-    return false;
-  }
+    await actor.update({
+        [LP_PATH]: newLP,
+        [AE_PATH]: newAE
+    });
 
-  // LP -> AE, AE deckeln
-  const aeToAdd = Math.min(amount, Math.max(0, maxAE - currentAE));
-  const newAE = currentAE + aeToAdd;
-  const newLP = Math.max(0, currentLP - amount);
+    ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor }),
+        content: dict.convertedMsg.replace("{amount}", String(aeToAdd))
+    });
 
-  // Update des eigenen Actors
-  await actor.update({
-    [dict.lpPath]: newLP,
-    [dict.aePath]: newAE
-  });
+    let loss = 1;
+    try {
+        const lossRoll = await new Roll("1d3").evaluate();
+        loss = Number(lossRoll.total) || 1;
+    } catch (err) {
+        console.warn("Astrale Meditation: Fehler beim Würfeln des LeP-Verlusts.", err);
+    }
 
-  // Chat: Umwandlung
-  ChatMessage.create({
-    speaker: ChatMessage.getSpeaker({ actor }),
-    content: dict.convertedMsg.replace("{amount}", String(aeToAdd))
-  });
+    const lpAfterConv = Number(gp(actor, LP_PATH)) || newLP;
+    const lpAfterLoss = Math.max(0, lpAfterConv - loss);
 
-  // 1W3 LeP Verlust – evaluieren
-  let loss = 1;
-  try {
-    const lossRoll = new Roll("1d3").evaluateSync();
-    loss = Number(lossRoll.total) || 1;
-  } catch (err) {
-    const lossRoll = new Roll("1d3");
-    await lossRoll.toMessage({ speaker: ChatMessage.getSpeaker({ actor }), flavor: lang === "de" ? "1W3 LeP Verlust" : "1D3 LP loss" });
-    loss = Number(lossRoll.total) || 1;
-  }
+    await actor.update({
+        [LP_PATH]: lpAfterLoss
+    });
 
-  // Verlust anwenden
-  const lpAfterConv = Number(gp(actor, dict.lpPath)) || newLP;
-  const lpAfterLoss = Math.max(0, lpAfterConv - loss);
-
-  await actor.update({
-    [dict.lpPath]: lpAfterLoss
-  });
-
-  // Abschlussmeldung
-  ChatMessage.create({
-    speaker: ChatMessage.getSpeaker({ actor }),
-    content: dict.postLoss(loss, actorName)
-  });
-
-  return true;
+    ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor }),
+        content: dict.postLoss(loss, actorName)
+    });
 }
 
-let dialogRef = null;
-
-dialogRef = new Dialog({
-  title: dict.title,
-  content,
-  buttons: {
-    convert: {
-      label: dict.convert,
-      callback: async (html) => {
-        // Den Button-Node aus dem Dialog holen, um ihn bei Over-Max zu deaktivieren
-        const btn = dialogRef.element?.find('button[data-button="convert"]')?.get(0);
-        return await doConversion(html, maxConvert, btn);
-      }
+const dialog = new foundry.applications.api.DialogV2({
+    window: { 
+        title: dict.title,
+        resizable: true
     },
-    cancel: { label: dict.cancel }
-  },
-  default: "convert",
-  render: (html) => {
-    const inputEl = html.find("#lepInput")[0];
-    const btn = dialogRef?.element?.find('button[data-button="convert"]')?.get(0);
+    classes: ["dsa5"],
+    position: { width: 450, height: "auto" },
+    content: content,
+    buttons: [{
+        action: "convert",
+        label: dict.convert,
+        icon: "fas fa-magic", 
+        default: true,
+        callback: async (event, button, dialog) => {
+            const inputEl = dialog.element.querySelector('#lepInput');
+            const rawVal = inputEl ? inputEl.value : 0;
+            await doConversion(rawVal, maxConvert);
+        }
+    }, {
+        action: "cancel",
+        label: dict.cancel,
+        icon: "fas fa-times"
+    }]
+});
 
-    // Enter bestätigt die Eingabe
+dialog.render({ force: true }).then(() => {
+    const inputEl = dialog.element.querySelector('#lepInput');
     if (inputEl) {
-      inputEl.addEventListener("keydown", async (ev) => {
-        if (ev.key === "Enter") {
-          ev.preventDefault();
-          await doConversion(html, maxConvert, btn);
-        }
-      });
-
-      // Live-Validierung: Button bei Over-Max visuell deaktivieren
-      inputEl.addEventListener("input", () => {
-        const val = Math.floor(Number(inputEl.value ?? 0));
-        if (btn) {
-          if (val > maxConvert) {
-            btn.disabled = true;
-            btn.classList.add("disabled");
-          } else {
-            btn.disabled = false;
-            btn.classList.remove("disabled");
-          }
-        }
-      });
-
-      
-      const initialVal = Math.floor(Number(inputEl.value ?? 0));
-      if (btn) {
-        btn.disabled = initialVal > maxConvert;
-        btn.classList.toggle("disabled", initialVal > maxConvert);
-      }
+        inputEl.addEventListener('input', (e) => {
+            let val = parseInt(e.target.value);
+            if (!isNaN(val) && val > inputMax) {
+                e.target.value = inputMax;
+            }
+        });
     }
-  }
+});


### PR DESCRIPTION
Verwendete Icons:

[fas fa-tint](https://fontawesome.com/v4/icon/magic)
[fas fa-times](https://fontawesome.com/v4/icon/times)

Probe auf Selbstbeherrschung: Bei Erfolg wird GUI mit Textbeschreibung geöffnet.

Eingabefeld für umzuwandelnden LeP wert. Wenn über Maximum (qs x 3) wird der Button zum umwandeln deaktiviert. Enter bestätigt auch die eingabe der Probe.
LeP werden abgezogen AsP gutgeschrieben.
1d3 LeP werden zusätzlich abgezogen, entsprechende Chatnachrichten werden verfasst.