### PR TITLE
Pyrophor (Katakomben & Ruinen / Explorers)

### DIFF
--- a/macros/consumable/Pyrophor.js
+++ b/macros/consumable/Pyrophor.js
@@ -1,0 +1,82 @@
+// This is a system macro used for automation. It is disfunctional without the proper context.
+
+        const { getProperty, setProperty } = foundry.utils;
+        
+      
+        const lang = game.i18n.lang == "de" ? "de" : "en";
+        const dict = {
+          de: { talent_gaukeleien: "Gaukeleien" },
+          en: { talent_gaukeleien: "Gaukelei" } 
+        };
+        const TALENT = dict[lang].talent_gaukeleien;
+        
+        // QS aus Item-Kontext
+        const durationDefault = [300, 600, 900, 1200, 1800, 2700][qs - 1];
+        
+        // Boni 
+        const fpBonus = [1, 1, 1, 2, 2, 0][qs - 1]; // QS 1–5
+        const qlBonus = [0, 0, 0, 0, 0, 1][qs - 1]; // QS 6
+        
+        // Lichtdauer in Sekunden (Kerze) – wird auch für Bonus-Condition genutzt
+        const lightSeconds = [0, 6, 12, 12, 18, 18][qs - 1];
+        
+        // 1) Bonus-ActiveEffect         
+        {
+          let changes = [];
+          if (qlBonus > 0) {
+            changes = [{
+              key: "system.skillModifiers.QL",
+              mode: 0,
+              value: `${TALENT} ${qlBonus}`
+            }];
+          } else if (fpBonus > 0) {
+            changes = [{
+              key: "system.skillModifiers.FP",
+              mode: 0,
+              value: `${TALENT} ${fpBonus}`
+            }];
+          }
+        
+          if (changes.length && lightSeconds > 0) {
+            const condition = {
+              name: "Pyrophor: Gaukeleien-Bonus",
+              icon: "icons/svg/aura.svg",
+              changes,
+              duration: {
+                seconds: lightSeconds,               
+                startTime: game.time.worldTime
+              },
+              flags: {
+                dsa5: { description: "Pyrophor" }    
+              },
+              type: "base",
+              disabled: false,
+              system: {}
+            };
+            await actor.addCondition(condition);
+          }
+        }
+        
+        // 2) Licht 
+        if (lightSeconds > 0) {
+          const tokens = actor.getActiveTokens?.() || [];
+          if (tokens.length) {
+            const lightID = "candle"; 
+            const itemName = "Pyrophor";
+        
+            await game.dsa5.apps.LightDialog.applyVisionOrLight(true, lightID, tokens, itemName);
+        
+            setTimeout(async () => {
+              const ae = actor.effects.find(e => e.name === itemName);
+              if (ae) {
+                await ae.update({
+                  duration: {
+                    seconds: lightSeconds,
+                    startTime: game.time.worldTime
+                  }
+                });
+              }
+            }, 100);
+          }
+        }
+        

--- a/macros/consumable/Pyrophor.js
+++ b/macros/consumable/Pyrophor.js
@@ -1,82 +1,52 @@
 // This is a system macro used for automation. It is disfunctional without the proper context.
 
-        const { getProperty, setProperty } = foundry.utils;
-        
-      
-        const lang = game.i18n.lang == "de" ? "de" : "en";
-        const dict = {
-          de: { talent_gaukeleien: "Gaukeleien" },
-          en: { talent_gaukeleien: "Gaukelei" } 
-        };
-        const TALENT = dict[lang].talent_gaukeleien;
-        
-        // QS aus Item-Kontext
-        const durationDefault = [300, 600, 900, 1200, 1800, 2700][qs - 1];
-        
-        // Boni 
-        const fpBonus = [1, 1, 1, 2, 2, 0][qs - 1]; // QS 1–5
-        const qlBonus = [0, 0, 0, 0, 0, 1][qs - 1]; // QS 6
-        
-        // Lichtdauer in Sekunden (Kerze) – wird auch für Bonus-Condition genutzt
-        const lightSeconds = [0, 6, 12, 12, 18, 18][qs - 1];
-        
-        // 1) Bonus-ActiveEffect         
-        {
-          let changes = [];
-          if (qlBonus > 0) {
-            changes = [{
-              key: "system.skillModifiers.QL",
-              mode: 0,
-              value: `${TALENT} ${qlBonus}`
-            }];
-          } else if (fpBonus > 0) {
-            changes = [{
-              key: "system.skillModifiers.FP",
-              mode: 0,
-              value: `${TALENT} ${fpBonus}`
-            }];
-          }
-        
-          if (changes.length && lightSeconds > 0) {
-            const condition = {
-              name: "Pyrophor: Gaukeleien-Bonus",
-              icon: "icons/svg/aura.svg",
-              changes,
-              duration: {
-                seconds: lightSeconds,               
-                startTime: game.time.worldTime
-              },
-              flags: {
-                dsa5: { description: "Pyrophor" }    
-              },
-              type: "base",
-              disabled: false,
-              system: {}
-            };
-            await actor.addCondition(condition);
-          }
-        }
-        
-        // 2) Licht 
-        if (lightSeconds > 0) {
-          const tokens = actor.getActiveTokens?.() || [];
-          if (tokens.length) {
-            const lightID = "candle"; 
-            const itemName = "Pyrophor";
-        
-            await game.dsa5.apps.LightDialog.applyVisionOrLight(true, lightID, tokens, itemName);
-        
-            setTimeout(async () => {
-              const ae = actor.effects.find(e => e.name === itemName);
-              if (ae) {
-                await ae.update({
-                  duration: {
-                    seconds: lightSeconds,
-                    startTime: game.time.worldTime
-                  }
-                });
-              }
-            }, 100);
-          }
-        }
-        
+const lang = (game.i18n.lang === "de") ? "de" : "en";
+const dict = { de: { talent_gaukeleien: "Gaukeleien" }, en: { talent_gaukeleien: "Gaukelei" } }; 
+const TALENT = dict[lang].talent_gaukeleien;
+
+const durationDefault = [300, 600, 900, 1200, 1800, 2700][qs - 1];
+const fpBonus = [1, 1, 1, 2, 2, 0][qs - 1];
+const qlBonus = [0, 0, 0, 0, 0, 1][qs - 1];
+const lightSeconds = [0, 6, 12, 12, 18, 18][qs - 1];
+
+// Bonus-ActiveEffect, Dauer = 30 Sekunden (konstant)
+{
+  let changes = [];
+  if (qlBonus > 0) {
+    changes = [{ key: "system.skillModifiers.QL", mode: 0, value: `${TALENT} ${qlBonus}` }];
+  } else if (fpBonus > 0) {
+    changes = [{ key: "system.skillModifiers.FP", mode: 0, value: `${TALENT} ${fpBonus}` }];
+  }
+
+  if (changes.length) {
+    const condition = {
+      name: "Pyrophor: Gaukeleien-Bonus",
+      icon: "icons/svg/aura.svg",
+      changes: changes,
+      duration: { seconds: 30, startTime: game.time.worldTime }, 
+      flags: { dsa5: { description: "Pyrophor" } }, 
+      type: "base",
+      disabled: false,
+      system: {}
+    };
+    await actor.addCondition(condition);
+  }
+}
+
+// Licht 
+if (lightSeconds > 0) {
+  const tokens = actor.getActiveTokens?.() || [];
+  if (tokens.length) {
+    const lightID = "candle";
+    const itemName = "Pyrophor";
+
+    await game.dsa5.apps.LightDialog.applyVisionOrLight(true, lightID, tokens, itemName);
+
+    setTimeout(async () => {
+      const ae = actor.effects.find(e => e.name === itemName);
+      if (ae) {
+        await ae.update({ duration: { seconds: lightSeconds, startTime: game.time.worldTime } });
+      }
+    }, 100);
+  }
+}


### PR DESCRIPTION
Macht ein Licht wenn item qs >1; Lichtdauer abhängig von Itemqs.
GIbt Boni auf Gaukelleien, siehe [Regel](https://dsa.ulisses-regelwiki.de/Pyrophor.html);