### PR TITLE
Waffenschwärze (Aventurian Amory I)

### DIFF
--- a/macros/items/Waffenschwärze.js
+++ b/macros/items/Waffenschwärze.js
@@ -1,0 +1,106 @@
+// This is a system macro used for automation. It is disfunctional without the proper context.
+
+const lang = game.i18n.lang == "de" ? "de" : "en"
+const dict = {
+  de: {
+    descr: "Welche Waffe soll geschwärzt werden?",
+    msg: (actor, name) => `${actor} hat ${name} geschwärzt.`,
+    effectName: "Geschwärzt Waffe",
+    skillHide: "Verbergen"
+  },
+  en: {
+    descr: "Which weapon should be treated with 'Blackened'?",
+    msg: (actor, name) => `${actor} has blackened ${name}.`,
+    effectName: "Blackened Weapon",
+    skillHide: "Stealth" 
+  }
+}[lang]
+
+// Nur Nahkampfwaffen ohne bestehenden Geschwärzt/Blackened-Effekt
+const weapons = actor.items.filter(it => {
+  if (it.type !== "meleeweapon") return false
+  const hasBlackened = (it.effects ?? []).some(e => (e.name ?? "").match(new RegExp(dict.effectName, "i")))
+  return !hasBlackened
+})
+
+const options = []
+let index = 0
+for (let item of weapons) {
+  const el = `<input type="radio" id="item_${item.id}" class="dsahidden" name="choice" value="${item.id}" ${index == 0 ? "checked" : ""}/><label for="item_${item.id}" class="slot" data-id="${item.id}" data-tooltip="${item.name}">
+          <div style="background-image:url('${item.img}')"></div>
+  </label>`
+  options.push(el)
+  index += 1
+}
+
+const finishBlackened = async (choice) => {
+  const weapon = actor.items.get(choice)
+  if (!weapon) return
+
+  const effectData = {
+    name: dict.effectName,
+    img: "icons/svg/aura.svg",
+    description: dict.effectName,
+    disabled: false,
+    transfer: true,
+    duration: {
+      seconds: 3600,
+      startTime: game.time.worldTime ?? 0
+    },
+    changes: [
+      { key: "system.skillModifiers.step", mode: 0, value: `${dict.skillHide} 1`, priority: null }
+    ],
+    flags: {
+      dsa5: {
+        applyToOwner: true,
+        hideOnToken: true,
+        hidePlayers: false,
+        description: dict.effectName
+      },
+      autoRemoveOnExpire: true
+    },
+    type: "base",
+    statuses: []
+  }
+
+  // Effekt an der Waffe erzeugen
+  const created = await weapon.createEmbeddedDocuments("ActiveEffect", [effectData])
+
+  // Chat-Nachricht
+  await ChatMessage.create(game.dsa5.apps.DSA5_Utility.chatDataSetup(dict.msg(actor.name, weapon.name)))
+
+  // Cleanup: Sobald der Effekt abläuft (disabled durch Duration), entfernen
+  const effectId = created[0]?.id
+  if (!effectId) return
+
+  // Hook: wenn dieser Effekt disabled wird (Ablauf), wird er gelöscht.
+  const hookId = Hooks.on("updateActiveEffect", async (effect, changes, context, userId) => {
+    try {
+      if (effect?.id !== effectId) return
+      if (changes?.disabled === true || (changes?.duration?.remaining !== undefined && changes.duration.remaining <= 0)) {
+        await weapon.deleteEmbeddedDocuments("ActiveEffect", [effectId])
+        Hooks.off("updateActiveEffect", hookId)
+      }
+    } catch (err) {
+      console.error("Auto-remove blackened effect failed:", err)
+      Hooks.off("updateActiveEffect", hookId)
+    }
+  })
+}
+
+new foundry.applications.api.DialogV2({
+  window: { title: dict.effectName },
+  content: `<p>${dict.descr}</p><style>input[type="radio"]:checked + label { border-color: darkred; box-shadow: inset 0 0px 10px 3px black}</style><div class="bags row-section wrap" style="font-size: 45px;line-height: 50px;text-align: center;">
+      ${options.join("")}
+  </div>`,
+  buttons: [{
+    action: "ok",
+    label: "ok",
+    default: true,
+    callback: (event, button, dialog) => button.form.elements.choice.value
+  }],
+  submit: result => {
+    finishBlackened(result)
+  }
+}).render({ force: true })
+

--- a/macros/items/Waffenschwärze.js
+++ b/macros/items/Waffenschwärze.js
@@ -16,91 +16,130 @@ const dict = {
   }
 }[lang]
 
-// Nur Nahkampfwaffen ohne bestehenden Geschwärzt/Blackened-Effekt
+if (!actor) {
+    ui.notifications.warn(lang === "de" ? "Kein Actor gefunden." : "No actor found.");
+    return;
+}
+
+// Nur Nahkampfwaffen erlauben, die aktuell KEINEN AKTIVEN Geschwärzt-Effekt haben.
 const weapons = actor.items.filter(it => {
   if (it.type !== "meleeweapon") return false
-  const hasBlackened = (it.effects ?? []).some(e => (e.name ?? "").match(new RegExp(dict.effectName, "i")))
-  return !hasBlackened
+  const hasActiveBlackened = (it.effects ?? []).some(e => 
+      (e.name ?? "").match(new RegExp(dict.effectName, "i")) && e.disabled === false
+  )
+  return !hasActiveBlackened
 })
+
+if (weapons.length === 0) {
+    ui.notifications.warn(lang === "de" ? "Keine passenden Waffen gefunden." : "No matching weapons found.");
+    return;
+}
+
+const styleId = "blackened-weapon-styles";
+if (!document.getElementById(styleId)) {
+    document.head.insertAdjacentHTML("beforeend", `
+        <style id="${styleId}">
+            /* Alle Regeln greifen NUR innerhalb unseres speziellen Containers */
+            #dsa-blackened-weapon-container .weapon-choice { display: inline-block; cursor: pointer; margin: 8px; }
+            #dsa-blackened-weapon-container .weapon-choice input[type="radio"] { display: none !important; }
+            #dsa-blackened-weapon-container .weapon-img {
+                width: 50px; height: 50px; background-size: cover; background-position: center;
+                border: 1px solid #7a7971; 
+                border-radius: 3px; 
+                box-shadow: 0 0 3px rgba(0,0,0,0.3);
+                transition: all 0.2s ease-in-out; 
+                opacity: 0.8;
+            }
+            #dsa-blackened-weapon-container .weapon-choice:hover .weapon-img { opacity: 1.0; }
+            #dsa-blackened-weapon-container .weapon-choice input[type="radio"]:checked + .weapon-img {
+                border: 2px solid #000000 !important; 
+                box-shadow: inset 0 0 8px rgba(0,0,0,0.7) !important;
+                opacity: 1.0 !important;
+            }
+            #dsa-blackened-weapon-container .weapon-wrap { 
+                display: flex; flex-wrap: wrap; gap: 5px; justify-content: center; margin-top: 15px; margin-bottom: 10px; 
+            }
+        </style>
+    `);
+}
 
 const options = []
 let index = 0
 for (let item of weapons) {
-  const el = `<input type="radio" id="item_${item.id}" class="dsahidden" name="choice" value="${item.id}" ${index == 0 ? "checked" : ""}/><label for="item_${item.id}" class="slot" data-id="${item.id}" data-tooltip="${item.name}">
-          <div style="background-image:url('${item.img}')"></div>
+  const el = `
+  <label class="weapon-choice" data-tooltip="${item.name}">
+      <input type="radio" name="choice" value="${item.id}" ${index === 0 ? "checked" : ""} />
+      <div class="weapon-img" style="background-image:url('${item.img}')"></div>
   </label>`
   options.push(el)
   index += 1
 }
 
 const finishBlackened = async (choice) => {
+  if (!choice) return;
   const weapon = actor.items.get(choice)
   if (!weapon) return
 
-  const effectData = {
-    name: dict.effectName,
-    img: "icons/svg/aura.svg",
-    description: dict.effectName,
-    disabled: false,
-    transfer: true,
-    duration: {
-      seconds: 3600,
-      startTime: game.time.worldTime ?? 0
-    },
-    changes: [
-      { key: "system.skillModifiers.step", mode: 0, value: `${dict.skillHide} 1`, priority: null }
-    ],
-    flags: {
-      dsa5: {
-        applyToOwner: true,
-        hideOnToken: true,
-        hidePlayers: false,
-        description: dict.effectName
-      },
-      autoRemoveOnExpire: true
-    },
-    type: "base",
-    statuses: []
+  const durationData = {
+    seconds: 3600,
+    startTime: game.time.worldTime ?? 0
   }
 
-  // Effekt an der Waffe erzeugen
-  const created = await weapon.createEmbeddedDocuments("ActiveEffect", [effectData])
+  const existingEffect = weapon.effects.find(e => (e.name ?? "").match(new RegExp(dict.effectName, "i")))
 
-  // Chat-Nachricht
-  await ChatMessage.create(game.dsa5.apps.DSA5_Utility.chatDataSetup(dict.msg(actor.name, weapon.name)))
-
-  // Cleanup: Sobald der Effekt abläuft (disabled durch Duration), entfernen
-  const effectId = created[0]?.id
-  if (!effectId) return
-
-  // Hook: wenn dieser Effekt disabled wird (Ablauf), wird er gelöscht.
-  const hookId = Hooks.on("updateActiveEffect", async (effect, changes, context, userId) => {
-    try {
-      if (effect?.id !== effectId) return
-      if (changes?.disabled === true || (changes?.duration?.remaining !== undefined && changes.duration.remaining <= 0)) {
-        await weapon.deleteEmbeddedDocuments("ActiveEffect", [effectId])
-        Hooks.off("updateActiveEffect", hookId)
-      }
-    } catch (err) {
-      console.error("Auto-remove blackened effect failed:", err)
-      Hooks.off("updateActiveEffect", hookId)
+  if (existingEffect) {
+    await existingEffect.update({
+        disabled: false,
+        duration: durationData
+    })
+  } else {
+    const effectData = {
+      name: dict.effectName,
+      img: "icons/svg/aura.svg",
+      description: dict.effectName,
+      disabled: false,
+      transfer: true,
+      duration: durationData,
+      changes: [
+        { key: "system.skillModifiers.step", mode: 0, value: `${dict.skillHide} 1`, priority: null }
+      ],
+      flags: {
+        dsa5: {
+          applyToOwner: true,
+          hideOnToken: true,
+          hidePlayers: false,
+          description: dict.effectName
+        }
+      },
+      type: "base",
+      statuses: []
     }
-  })
+    await weapon.createEmbeddedDocuments("ActiveEffect", [effectData])
+  }
+
+  await ChatMessage.create(game.dsa5.apps.DSA5_Utility.chatDataSetup(dict.msg(actor.name, weapon.name)))
 }
 
 new foundry.applications.api.DialogV2({
   window: { title: dict.effectName },
-  content: `<p>${dict.descr}</p><style>input[type="radio"]:checked + label { border-color: darkred; box-shadow: inset 0 0px 10px 3px black}</style><div class="bags row-section wrap" style="font-size: 45px;line-height: 50px;text-align: center;">
-      ${options.join("")}
+  classes: ["dsa5"], 
+  content: `
+  <div id="dsa-blackened-weapon-container">
+      <p style="text-align: center; font-style: italic;">${dict.descr}</p>
+      <div class="weapon-wrap">
+          ${options.join("")}
+      </div>
   </div>`,
   buttons: [{
     action: "ok",
     label: "ok",
     default: true,
-    callback: (event, button, dialog) => button.form.elements.choice.value
+    callback: (event, button, dialog) => {
+        const checked = dialog.element.querySelector('input[name="choice"]:checked');
+        return checked ? checked.value : null;
+    }
   }],
   submit: result => {
     finishBlackened(result)
   }
 }).render({ force: true })
-

--- a/macros/items/Waffenschwärze.js
+++ b/macros/items/Waffenschwärze.js
@@ -43,7 +43,7 @@ for (let item of weapons) {
   <li>
       <label data-tooltip="${item.name}">
           <input type="radio" name="choice" value="${item.id}" ${index === 0 ? "checked" : ""} />
-          <img src="${item.img}" width="40" height="40" style="object-fit: contain; border: none;"/>
+          <img src="${item.img}" width="40" height="40" class="dsa-card-icon-img"/>
           <span>${item.name}</span>
       </label>
   </li>`
@@ -97,20 +97,14 @@ const finishBlackened = async (choice) => {
 }
 
 new foundry.applications.api.DialogV2({
-  window: { 
-      title: dict.effectName,
-      resizable: true 
-  },
-  position: {
-      width: 450,
-      height: "auto"
-  },
+  window: { title: dict.effectName, resizable: true },
+  position: { width: 450, height: "auto" },
   classes: ["dsa5"], 
   content: `
   <div class="marginBottom">
       <p class="center"><i>${dict.descr}</i></p>
       
-      <div class="dsa-card-list thinscroll" style="max-height: 40vh; overflow-y: auto; padding-right: 5px;">
+      <div class="dsa-card-list thinscroll dsa-card-scroll-box">
           <ul>
               ${options.join("")}
           </ul>

--- a/macros/items/Waffenschwärze.js
+++ b/macros/items/Waffenschwärze.js
@@ -6,13 +6,15 @@ const dict = {
     descr: "Welche Waffe soll geschwärzt werden?",
     msg: (actor, name) => `${actor} hat ${name} geschwärzt.`,
     effectName: "Geschwärzt Waffe",
-    skillHide: "Verbergen"
+    skillHide: "Verbergen",
+    btnLabel: "Schwärzen"
   },
   en: {
     descr: "Which weapon should be treated with 'Blackened'?",
     msg: (actor, name) => `${actor} has blackened ${name}.`,
     effectName: "Blackened Weapon",
-    skillHide: "Stealth" 
+    skillHide: "Stealth",
+    btnLabel: "Blacken"
   }
 }[lang]
 
@@ -21,7 +23,6 @@ if (!actor) {
     return;
 }
 
-// Nur Nahkampfwaffen erlauben, die aktuell KEINEN AKTIVEN Geschwärzt-Effekt haben.
 const weapons = actor.items.filter(it => {
   if (it.type !== "meleeweapon") return false
   const hasActiveBlackened = (it.effects ?? []).some(e => 
@@ -35,42 +36,17 @@ if (weapons.length === 0) {
     return;
 }
 
-const styleId = "blackened-weapon-styles";
-if (!document.getElementById(styleId)) {
-    document.head.insertAdjacentHTML("beforeend", `
-        <style id="${styleId}">
-            /* Alle Regeln greifen NUR innerhalb unseres speziellen Containers */
-            #dsa-blackened-weapon-container .weapon-choice { display: inline-block; cursor: pointer; margin: 8px; }
-            #dsa-blackened-weapon-container .weapon-choice input[type="radio"] { display: none !important; }
-            #dsa-blackened-weapon-container .weapon-img {
-                width: 50px; height: 50px; background-size: cover; background-position: center;
-                border: 1px solid #7a7971; 
-                border-radius: 3px; 
-                box-shadow: 0 0 3px rgba(0,0,0,0.3);
-                transition: all 0.2s ease-in-out; 
-                opacity: 0.8;
-            }
-            #dsa-blackened-weapon-container .weapon-choice:hover .weapon-img { opacity: 1.0; }
-            #dsa-blackened-weapon-container .weapon-choice input[type="radio"]:checked + .weapon-img {
-                border: 2px solid #000000 !important; 
-                box-shadow: inset 0 0 8px rgba(0,0,0,0.7) !important;
-                opacity: 1.0 !important;
-            }
-            #dsa-blackened-weapon-container .weapon-wrap { 
-                display: flex; flex-wrap: wrap; gap: 5px; justify-content: center; margin-top: 15px; margin-bottom: 10px; 
-            }
-        </style>
-    `);
-}
-
 const options = []
 let index = 0
 for (let item of weapons) {
   const el = `
-  <label class="weapon-choice" data-tooltip="${item.name}">
-      <input type="radio" name="choice" value="${item.id}" ${index === 0 ? "checked" : ""} />
-      <div class="weapon-img" style="background-image:url('${item.img}')"></div>
-  </label>`
+  <li>
+      <label data-tooltip="${item.name}">
+          <input type="radio" name="choice" value="${item.id}" ${index === 0 ? "checked" : ""} />
+          <img src="${item.img}" width="40" height="40" style="object-fit: contain; border: none;"/>
+          <span>${item.name}</span>
+      </label>
+  </li>`
   options.push(el)
   index += 1
 }
@@ -121,18 +97,28 @@ const finishBlackened = async (choice) => {
 }
 
 new foundry.applications.api.DialogV2({
-  window: { title: dict.effectName },
+  window: { 
+      title: dict.effectName,
+      resizable: true 
+  },
+  position: {
+      width: 450,
+      height: "auto"
+  },
   classes: ["dsa5"], 
   content: `
-  <div id="dsa-blackened-weapon-container">
-      <p style="text-align: center; font-style: italic;">${dict.descr}</p>
-      <div class="weapon-wrap">
-          ${options.join("")}
+  <div class="marginBottom">
+      <p class="center"><i>${dict.descr}</i></p>
+      
+      <div class="dsa-card-list thinscroll" style="max-height: 40vh; overflow-y: auto; padding-right: 5px;">
+          <ul>
+              ${options.join("")}
+          </ul>
       </div>
   </div>`,
   buttons: [{
     action: "ok",
-    label: "ok",
+    label: dict.btnLabel,
     default: true,
     callback: (event, button, dialog) => {
         const checked = dialog.element.querySelector('input[name="choice"]:checked');


### PR DESCRIPTION
CSS:

```
.dsa-card-scroll-box {
    max-height: 40vh;
    overflow-y: auto;
    padding-right: 5px;
}


.dsa-card-icon-img {
    object-fit: contain;
    border: none !important;
}

```

Umsetzung der Tätigkeit "Schwärzen" (Item hieß ursprünglich so, wurde von mir auf "Waffenschwärze" umbenannt.)
<img width="533" height="432" alt="grafik" src="https://github.com/user-attachments/assets/e05ec5e9-66b5-46f2-b79f-7293be3d8176" />


Durchsucht Nahkampfwaffen (außer diese die geschwärzt sind). Fügt den Effekt der Verbergenerleichterung der Waffe hinzu.
Nach Ablaufen der Effektdauer wird der Effekt wieder per Hook entfernt.