### PR TITLE
Trank der tausend Augen (Arcanelabs)

### DIFF
--- a/macros/consumable/Trank_der_tausend_augen.js
+++ b/macros/consumable/Trank_der_tausend_augen.js
@@ -1,0 +1,22 @@
+// This is a system macro used for automation. It is disfunctional without the proper context.
+
+{
+  const DURATION = 1200;
+
+  const sightMod   = [2, 1, 0, 0, 0, 0][qs - 1]; // Sichtmodifikator
+  const sightbonus = [0, 1, 2, 2, 3, 3][qs - 1]; // Sinnesschärfe-Bonus
+  const awBonus    = [0, 1, 1, 1, 2, 2][qs - 1]; // AW-Bonus
+  const needsConf  = [false, false, false, false, false, true][qs - 1]; // QS6
+
+  const changes = [];
+  if (sightMod > 0)    changes.push({ key: "system.sightModifier", mode: 2, value: sightMod });
+  if (sightbonus > 0)  changes.push({ key: "system.skillModifiers.step", mode: 0, value: `Sinnesschärfe ${sightbonus}` });
+  if (awBonus > 0)     changes.push({ key: "system.status.dodge.gearmodifier", mode: 2, value: awBonus }); 
+  if (needsConf)       changes.push({ key: "system.condition.confused", mode: 2, value: 1 });
+
+  actor.createEmbeddedDocuments("ActiveEffect", [{
+    name: "Trank der tausend Augen",
+    icon: "icons/svg/aura.svg",
+    duration: { seconds: DURATION, startTime: game.time.worldTime },
+    changes
+  }]

--- a/macros/consumable/Trank_der_tausend_augen.js
+++ b/macros/consumable/Trank_der_tausend_augen.js
@@ -1,22 +1,39 @@
 // This is a system macro used for automation. It is disfunctional without the proper context.
 
-{
+const lang = game.i18n.lang == "de" ? "de" : "en";
+const dict = {
+  de: {
+    name: "Trank der tausend Augen",
+    perception: "Sinnesschärfe",
+    noActor: "Kein Akteur für den Trank gefunden."
+  },
+  en: {
+    name: "Potion of a Thousand Eyes",
+    perception: "Perception",
+    noActor: "No actor found for this potion."
+  }
+}[lang];
+
+if (!actor) {
+  ui.notifications.warn(dict.noActor);
+} else {
   const DURATION = 1200;
 
   const sightMod   = [2, 1, 0, 0, 0, 0][qs - 1]; // Sichtmodifikator
   const sightbonus = [0, 1, 2, 2, 3, 3][qs - 1]; // Sinnesschärfe-Bonus
   const awBonus    = [0, 1, 1, 1, 2, 2][qs - 1]; // AW-Bonus
-  const needsConf  = [false, false, false, false, false, true][qs - 1]; // QS6
+  const needsConf  = [false, false, false, false, false, true][qs - 1]; // Verwirrung bei QS 6
 
   const changes = [];
-  if (sightMod > 0)    changes.push({ key: "system.sightModifier", mode: 2, value: sightMod });
-  if (sightbonus > 0)  changes.push({ key: "system.skillModifiers.step", mode: 0, value: `Sinnesschärfe ${sightbonus}` });
+  //  if (sightMod > 0)    changes.push({ key: "system.sightModifier", mode: 2, value: sightMod });
+  if (sightbonus > 0)  changes.push({ key: "system.skillModifiers.step", mode: 0, value: `${dict.perception} ${sightbonus}` });
   if (awBonus > 0)     changes.push({ key: "system.status.dodge.gearmodifier", mode: 2, value: awBonus }); 
   if (needsConf)       changes.push({ key: "system.condition.confused", mode: 2, value: 1 });
 
   actor.createEmbeddedDocuments("ActiveEffect", [{
-    name: "Trank der tausend Augen",
+    name: (typeof item !== "undefined" && item?.name) ? item.name : dict.name,
     icon: "icons/svg/aura.svg",
     duration: { seconds: DURATION, startTime: game.time.worldTime },
     changes
-  }]
+  }]);
+}

--- a/macros/consumable/Trank_der_tausend_augen.js
+++ b/macros/consumable/Trank_der_tausend_augen.js
@@ -25,13 +25,13 @@ if (!actor) {
   const needsConf  = [false, false, false, false, false, true][qs - 1]; // Verwirrung bei QS 6
 
   const changes = [];
-  //  if (sightMod > 0)    changes.push({ key: "system.sightModifier", mode: 2, value: sightMod });
+  // if (sightMod > 0)    changes.push({ key: "system.sightModifier", mode: 2, value: sightMod });
   if (sightbonus > 0)  changes.push({ key: "system.skillModifiers.step", mode: 0, value: `${dict.perception} ${sightbonus}` });
   if (awBonus > 0)     changes.push({ key: "system.status.dodge.gearmodifier", mode: 2, value: awBonus }); 
   if (needsConf)       changes.push({ key: "system.condition.confused", mode: 2, value: 1 });
 
   actor.createEmbeddedDocuments("ActiveEffect", [{
-    name: (typeof item !== "undefined" && item?.name) ? item.name : dict.name,
+    name: dict.name,
     icon: "icons/svg/aura.svg",
     duration: { seconds: DURATION, startTime: game.time.worldTime },
     changes


### PR DESCRIPTION
Der Sichtmodifikator hat aktuell keine Auswirkungen auf Talentproben.

Unsichtbares entdecken ist wohl foundry-seitig vorhanden, allerdings hat es in meinen Probeläufen nicht _zuverlässig_ funktioniert:
<img width="528" height="148" alt="grafik" src="https://github.com/user-attachments/assets/81ee5072-8b2f-47e7-962a-a511e002d596" />
Gibt es die möglichkeit hierzu einen aktiven effekt mit value=range zu erstellen?
Es gibt mehrere Fähigkeiten, die nur das sehen von bestimmten Akteuren erlauben (hier ist das Stufenabhängig - ein anderes Beispiel wäre der Anderswelt-Lidschatten), ist das umsetzbar?