### PR TITLE
Tarnele und Tarnelensalbe (Aventurisches Herbarium II)

### DIFF
--- a/macros/consumable/Tarnele.js
+++ b/macros/consumable/Tarnele.js
@@ -1,0 +1,39 @@
+// This is a system macro used for automation. It is disfunctional without the proper context.
+
+
+const { getProperty } = foundry.utils;
+
+// Schmerzstufe auslesen
+const getPain = () => Number(getProperty(actor, "system.condition.inpain"));
+
+// LePTemp um +1 erhöhen
+{
+  const before = Number(getProperty(actor, "system.status.regeneration.LePTemp")) || 0;
+  await actor.update({ "system.status.regeneration.LePTemp": before + 1 });
+}
+
+// Active Effect anlegen
+const EFFECT_NAME = "Tarnelensalbe";
+const EFFECT_ICON = "icons/svg/blood.svg";
+const shouldBeDisabled = getPain() !== 1;
+
+let eff = actor.effects.find(e => e.name === EFFECT_NAME);
+
+if (!eff) {
+  await actor.createEmbeddedDocuments("ActiveEffect", [
+    {
+      name: EFFECT_NAME,
+      icon: EFFECT_ICON,
+      origin: actor.uuid,
+      disabled: shouldBeDisabled, // aktiv nur bei inpain === 1
+      duration: { seconds: 3600 },
+      changes: [
+        { key: "system.resistances.effects", mode: 0, value: "inpain 1", priority: 20 }
+      ]
+    }
+  ]);
+} else {
+  if (eff.disabled !== shouldBeDisabled) {
+    await eff.update({ disabled: shouldBeDisabled });
+  }
+}


### PR DESCRIPTION
Umsetzung von 
<img width="999" height="297" alt="grafik" src="https://github.com/user-attachments/assets/74bb8ae4-467c-4b40-b47e-d9ffe8e815b2" />
Wobei man Pflanzen aktuell nicht mit einem on-use effekt versehen kann (ggf. umsetzen wenn möglich)?
Die Tarnelensalbe wiederrum ist noch nicht als Item angelegt.

Effekte:
LePTemp Erhöhung: 
Direkt beim Ausführen wird der temporäre Regenerationswert LePTemp des Actors um +1 erhöht.

Schmerzunterdrückung: 
Es wird ein Active Effect mit dem Namen „Tarnelensalbe“ für 3600 Sekunden angelegt (oder ein vorhandener gleichnamiger Effekt angepasst). Die Aktivität des Effekts wird einmalig beim Ausführen geprüft: Der Effekt ist nur aktiv, wenn system.condition.inpain exakt 1 ist. Andernfalls wird der Effekt disabled gesetzt.

Ich hatte versucht eine mögliche Aktualisierung des inpainwertes mittels hook zu überwachen, hat bei mir aber nicht hingehauen, deswegen aktuell nur die initiale Überprüfung - vlt gibt es da ja eine einfache Möglichkeit zu die ich nicht sehe.

