### PR TITLE
Tradition (Savant) (Aventurian Magic I)

### DIFF
--- a/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-dsa5.js
+++ b/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-dsa5.js
@@ -1,0 +1,161 @@
+import DSA5_Utility from '/systems/dsa5/modules/system/helpers/utility-dsa5.js';
+
+export default class SavantDSA5 {
+    static async handleSavant(message) {
+        const data = message.flags.data;
+        const actor = DSA5_Utility.getSpeaker(message.speaker) || (message.speaker?.actor ? game.actors.get(message.speaker.actor) : null);
+        const roll = this._getRollFromMessage(message);
+        if (!roll || !actor) return;
+
+        if (data.postData.successLevel === -2) return this._rescueBotch(message, actor);
+        if (data.postData.successLevel > 0) return this.renderSavantDialog(message, actor, roll);
+    }
+
+    static async renderSavantDialog(message, actor, roll) {
+        const data = message.flags.data;
+        const postData = data.postData;
+        const source = postData.source?.system ? postData.source : data.preData.source;
+        const chars = [source.system.characteristic1.value, source.system.characteristic2.value, source.system.characteristic3.value];
+        
+        const dialogData = {
+            description: game.i18n.localize("SAVANT.descriptionSavant"),
+            currentAsP: actor.system.status.astralenergy.value,
+            result: postData.result,
+            qualityStep: postData.qualityStep,
+            dice: roll.terms.filter(t => t.faces === 20).map((t, i) => ({
+                index: i, value: t.results[0].result, attr: chars[i].toLowerCase(),
+                cssClass: t.results[0].result <= postData.characteristics[i].tar ? "suc" : "fail",
+                tooltip: `${game.i18n.localize("CHAR." + chars[i].toUpperCase())} vs ${postData.characteristics[i].tar}`
+            }))
+        };
+
+        const content = await renderTemplate("modules/dsa5-magic-1/templates/savant-dialog.hbs", dialogData);
+        new Dialog({
+            title: game.i18n.localize("SAVANT.name"),
+            content,
+            buttons: {
+                confirm: { label: game.i18n.localize("SAVANT.confirm"), callback: (html) => this._applyChanges(html, message, actor, roll) },
+                cancel: { label: game.i18n.localize("SAVANT.cancel") }
+            },
+            render: (html) => this._activateListeners(html, postData, roll)
+        }).render(true);
+    }
+
+    static _activateListeners(html, postData, roll) {
+        html.find('.item').click(ev => {
+            const tab = $(ev.currentTarget).data('tab');
+            html.find('.item').removeClass('active');
+            $(ev.currentTarget).addClass('active');
+            html.find('.improve-controls, .add-fp-controls').hide();
+            if(tab === 'addFP') html.find('.add-fp-controls').show();
+            else if (tab === 'improve') html.find('.improve-controls').show();
+            this._updatePreview(html, postData, tab, roll);
+        });
+
+        html.find('.dieButton').click(ev => {
+            if (html.find('.item.active').data('tab') !== 'reroll') return;
+            $(ev.currentTarget).toggleClass('reroll-selected');
+            const checkbox = html.find(`.reroll-checkbox[data-index="${$(ev.currentTarget).data('index')}"]`);
+            checkbox.prop('checked', !checkbox.prop('checked'));
+            this._updatePreview(html, postData, 'reroll', roll);
+        });
+
+        html.find('.fp-input').on('change keyup', () => this._updatePreview(html, postData, 'addFP', roll));
+
+        html.find('.improve-btn').click(ev => {
+            const group = $(ev.currentTarget).closest('.die-group');
+            const dieSpan = group.find('.dieButton span');
+            let val = parseInt(dieSpan.text());
+            const original = roll.terms.filter(t => t.faces === 20)[group.data('index')].results[0].result;
+            if ($(ev.currentTarget).hasClass('up') && val < original) val++;
+            else if ($(ev.currentTarget).hasClass('down') && val > 1) val--;
+            dieSpan.text(val);
+            dieSpan.removeClass('fail suc').addClass(val <= postData.characteristics[group.data('index')].tar ? 'suc' : 'fail');
+            this._updatePreview(html, postData, 'improve', roll);
+        });
+    }
+
+    static _updatePreview(html, postData, mode, roll) {
+        let cost = 0, modifiedFW = postData.result;
+        if (mode === 'reroll') {
+            if (html.find('.reroll-checkbox:checked').length > 0) cost = 4;
+        } else if (mode === 'addFP') {
+            let added = Math.min(parseInt(html.find('.fp-input').val()) || 0, 18 - postData.result);
+            html.find('.fp-input').val(added);
+            cost = added * 5; modifiedFW += added;
+        } else if (mode === 'improve') {
+            let diffTotal = 0, savedPoints = 0;
+            html.find('.die-group').each((i, el) => {
+                const current = parseInt($(el).find('.dieButton span').text());
+                const original = roll.terms.filter(t => t.faces === 20)[i].results[0].result;
+                const target = postData.characteristics[i].tar;
+                if (original > current) {
+                    diffTotal += (original - current);
+                    savedPoints += (Math.max(0, original - target) - Math.max(0, current - target));
+                }
+            });
+            cost = diffTotal * 2; modifiedFW += savedPoints;
+        }
+        html.find('.asp-cost').text(cost);
+        html.find('.fw-preview').text(modifiedFW);
+        html.find('.qs-preview').text(Math.max(1, Math.min(6, Math.ceil(modifiedFW / 3))));
+    }
+
+    static async _applyChanges(html, message, actor, originalRoll) {
+        const cost = parseInt(html.find('.asp-cost').text());
+        if (actor.system.status.astralenergy.value < cost) return ui.notifications.warn(game.i18n.localize("SAVANT.notEnoughAsP"));
+        
+        await actor.update({"system.status.astralenergy.value": actor.system.status.astralenergy.value - cost});
+        const data = foundry.utils.duplicate(message.flags.data);
+        let roll = Roll.fromData(originalRoll.toJSON());
+        const d20s = roll.terms.filter(t => t.faces === 20);
+
+        const mode = html.find('.item.active').data('tab');
+        if (mode === 'reroll') {
+            const indices = html.find('.reroll-checkbox:checked').map((i, el) => $(el).data('index')).get();
+            for(let idx of indices) d20s[idx].results[0].result = (await new Roll("1d20").evaluate()).total;
+        } else if (mode === 'addFP') {
+            if (!data.preData.situationalModifiers) data.preData.situationalModifiers = [];
+            data.preData.situationalModifiers.push({ name: game.i18n.localize("SAVANT.addFP"), value: parseInt(html.find('.fp-input').val()) || 0, type: "FP" });
+        } else if (mode === 'improve') {
+            html.find('.die-group').each((i, el) => { d20s[i].results[0].result = parseInt($(el).find('.dieButton span').text()); });
+        }
+        
+        data.preData.roll = roll;
+        const DiceDSA5 = (await import('/systems/dsa5/modules/system/rolls/dice-dsa5.js')).default;
+        await actor[data.postData.postFunction]({ testData: data.preData, cardOptions: data }, { rerenderMessage: message });
+        await message.update({"flags.dsa5.savantUsed": true});
+    }
+
+    static async _rescueBotch(message, actor) {
+        const cost = 10;
+        if (actor.system.status.astralenergy.value < cost) return ui.notifications.warn(game.i18n.localize("SAVANT.notEnoughAsP"));
+        
+        new Dialog({
+            title: game.i18n.localize("SAVANT.name"),
+            content: `<p>${game.i18n.localize("SAVANT.botchRescue")}</p>`,
+            buttons: {
+                yes: {
+                    label: game.i18n.localize("SAVANT.confirm"),
+                    callback: async () => {
+                        await actor.update({"system.status.astralenergy.value": actor.system.status.astralenergy.value - cost});
+                        const failureLabel = game.i18n.localize("Failure");
+                        const updateData = {
+                            "flags.data.postData.successLevel": -1,
+                            "flags.data.postData.description": failureLabel,
+                            "flags.dsa5.savantUsed": true,
+                            "content": message.content.replace(/Patzer|Botch/g, failureLabel)
+                        };
+                        await message.update(updateData);
+                    }
+                },
+                cancel: { label: game.i18n.localize("SAVANT.cancel") }
+            }
+        }).render(true);
+    }
+
+    static _getRollFromMessage(message) {
+        const r = message.flags.data.postData?.roll || message.flags.data.preData?.roll;
+        return r instanceof Roll ? r : Roll.fromData(r);
+    }
+}

--- a/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-dsa5.js
+++ b/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-dsa5.js
@@ -49,6 +49,20 @@ export default class SavantDSA5 {
             html.find('.improve-controls, .add-fp-controls').hide();
             if(tab === 'addFP') html.find('.add-fp-controls').show();
             else if (tab === 'improve') html.find('.improve-controls').show();
+
+            html.find('.dieButton').removeClass('reroll-selected');
+            html.find('.reroll-checkbox').prop('checked', false);
+
+            const d20s = roll.terms.filter(t => t.faces === 20);
+            html.find('.die-group').each((i, el) => {
+                const originalVal = d20s[i].results[0].result;
+                const target = postData.characteristics[i].tar;
+                const dieSpan = $(el).find('.dieButton span');
+                
+                dieSpan.text(originalVal);
+                dieSpan.removeClass('fail suc').addClass(originalVal <= target ? 'suc' : 'fail');
+            });
+
             this._updatePreview(html, postData, tab, roll);
         });
 
@@ -64,13 +78,27 @@ export default class SavantDSA5 {
 
         html.find('.improve-btn').click(ev => {
             const group = $(ev.currentTarget).closest('.die-group');
+            const index = group.data('index');
             const dieSpan = group.find('.dieButton span');
             let val = parseInt(dieSpan.text());
-            const original = roll.terms.filter(t => t.faces === 20)[group.data('index')].results[0].result;
+            const original = roll.terms.filter(t => t.faces === 20)[index].results[0].result;
+            
+            let anotherDieModified = false;
+            html.find('.die-group').each((i, el) => {
+                if (i !== index) {
+                    const currentVal = parseInt($(el).find('.dieButton span').text());
+                    const originalVal = roll.terms.filter(t => t.faces === 20)[i].results[0].result;
+                    if (currentVal < originalVal) anotherDieModified = true;
+                }
+            });
+
+            if (anotherDieModified && $(ev.currentTarget).hasClass('down') && val === original) return;
+
             if ($(ev.currentTarget).hasClass('up') && val < original) val++;
             else if ($(ev.currentTarget).hasClass('down') && val > 1) val--;
+            
             dieSpan.text(val);
-            dieSpan.removeClass('fail suc').addClass(val <= postData.characteristics[group.data('index')].tar ? 'suc' : 'fail');
+            dieSpan.removeClass('fail suc').addClass(val <= postData.characteristics[index].tar ? 'suc' : 'fail');
             this._updatePreview(html, postData, 'improve', roll);
         });
     }

--- a/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-dsa5.js
+++ b/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-dsa5.js
@@ -1,5 +1,219 @@
 import DSA5_Utility from '/systems/dsa5/modules/system/helpers/utility-dsa5.js';
 
+const { ApplicationV2, DialogV2 } = foundry.applications.api;
+
+class SavantApp extends ApplicationV2 {
+    static DEFAULT_OPTIONS = {
+        id: "savant-app",
+        classes: ["dsa5"],
+        window: { resizable: true },
+        position: { width: 450, height: "auto" },
+        actions: {
+            switchTab: function(e, t) { this._onSwitchTab(e, t); },
+            toggleDie: function(e, t) { this._onToggleDie(e, t); },
+            adjustDie: function(e, t) { this._onAdjustDie(e, t); },
+            adjustFP: function(e, t) { this._onAdjustFP(e, t); },
+            confirm: function() { this._onConfirm(); },
+            cancel: function() { this.close(); }
+        }
+    };
+
+    constructor(message, actor, roll, options) {
+        super(options);
+        this.message = message;
+        this.dsaActor = actor;
+        this.originalRoll = roll;
+        
+        this.data = message.flags.data;
+        this.postData = this.data.postData;
+        this.preData = this.data.preData;
+        this.source = this.postData.source?.system ? this.postData.source : this.preData.source;
+        this.chars = [this.source.system.characteristic1.value, this.source.system.characteristic2.value, this.source.system.characteristic3.value];
+        this.d20s = roll.terms.filter(t => t.faces === 20);
+        
+        this.activeTab = 'reroll';
+        this.selectedForReroll = new Set();
+        this.addedFP = 0;
+        this.improvedDice = this.d20s.map(t => t.results[0].result);
+    }
+
+    get title() {
+        return game.i18n.localize("SAVANT.name");
+    }
+
+    async _renderHTML(context, options) {
+        return await renderTemplate("modules/dsa5-magic-1/templates/savant-dialog.hbs", context);
+    }
+
+    _replaceHTML(result, content, options) {
+        content.innerHTML = result;
+    }
+
+    async _prepareContext(options) {
+        let cost = 0;
+        let previewFW = this.postData.result;
+        
+        if (this.activeTab === 'reroll') {
+            if (this.selectedForReroll.size > 0) cost = 4;
+        } else if (this.activeTab === 'addFP') {
+            cost = this.addedFP * 5;
+            previewFW += this.addedFP;
+        } else if (this.activeTab === 'improve') {
+            let diffTotal = 0;
+            let savedPoints = 0;
+            this.improvedDice.forEach((current, i) => {
+                const original = this.d20s[i].results[0].result;
+                const target = this.postData.characteristics[i].tar;
+                if (original > current) {
+                    diffTotal += (original - current);
+                    savedPoints += (Math.max(0, original - target) - Math.max(0, current - target));
+                }
+            });
+            cost = diffTotal * 2;
+            previewFW += savedPoints;
+        }
+
+        const previewQS = Math.max(1, Math.min(6, Math.ceil(previewFW / 3)));
+
+        const dice = this.d20s.map((t, i) => {
+            const originalVal = t.results[0].result;
+            const currentVal = this.activeTab === 'improve' ? this.improvedDice[i] : originalVal;
+            const target = this.postData.characteristics[i].tar;
+            return {
+                index: i,
+                currentValue: currentVal,
+                attr: this.chars[i].toLowerCase(),
+                cssClass: currentVal <= target ? "suc" : "fail",
+                tooltip: `${game.i18n.localize("CHAR." + this.chars[i].toUpperCase())} vs ${target}`,
+                selected: this.activeTab === 'reroll' && this.selectedForReroll.has(i)
+            };
+        });
+
+        return {
+            description: game.i18n.localize("SAVANT.descriptionSavant"),
+            activeTab: this.activeTab,
+            isRerollTab: this.activeTab === 'reroll',
+            isImproveTab: this.activeTab === 'improve',
+            isAddFPTab: this.activeTab === 'addFP',
+            dice: dice,
+            addedFP: this.addedFP,
+            previewFW: previewFW,
+            previewQS: previewQS,
+            cost: cost,
+            currentAsP: this.dsaActor.system.status.astralenergy.value
+        };
+    }
+
+    
+    _onSwitchTab(event, target) {
+        this.activeTab = target.dataset.tab;
+        this.selectedForReroll.clear();
+        this.addedFP = 0;
+        this.improvedDice = this.d20s.map(t => t.results[0].result);
+        this.render();
+    }
+
+    _onToggleDie(event, target) {
+        if (this.activeTab !== 'reroll') return;
+        const idx = parseInt(target.closest('[data-index]').dataset.index);
+        if (this.selectedForReroll.has(idx)) this.selectedForReroll.delete(idx);
+        else this.selectedForReroll.add(idx);
+        this.render();
+    }
+
+    _onAdjustDie(event, target) {
+        if (this.activeTab !== 'improve') return;
+        const idx = parseInt(target.closest('[data-index]').dataset.index);
+        const delta = parseInt(target.closest('[data-delta]').dataset.delta);
+        
+        const original = this.d20s[idx].results[0].result;
+        let val = this.improvedDice[idx];
+
+        let anotherDieModified = this.improvedDice.some((v, i) => i !== idx && v < this.d20s[i].results[0].result);
+
+        if (anotherDieModified && delta === -1 && val === original) return;
+
+        if (delta === 1 && val < original) val++;
+        else if (delta === -1 && val > 1) val--;
+
+        this.improvedDice[idx] = val;
+        this.render();
+    }
+
+    _onAdjustFP(event, target) {
+        if (this.activeTab !== 'addFP') return;
+        const delta = parseInt(target.closest('[data-delta]').dataset.delta);
+        const max = 18 - this.postData.result; 
+        
+        let val = this.addedFP + delta;
+        this.addedFP = Math.min(Math.max(0, val), max);
+        this.render();
+    }
+
+    async _onConfirm() {
+        let cost = 0;
+        if (this.activeTab === 'reroll' && this.selectedForReroll.size > 0) cost = 4;
+        else if (this.activeTab === 'addFP') cost = this.addedFP * 5;
+        else if (this.activeTab === 'improve') {
+            let diffTotal = 0;
+            this.improvedDice.forEach((current, i) => {
+                const original = this.d20s[i].results[0].result;
+                if (original > current) diffTotal += (original - current);
+            });
+            cost = diffTotal * 2;
+        }
+
+        if (this.dsaActor.system.status.astralenergy.value < cost) {
+            return ui.notifications.warn(game.i18n.localize("SAVANT.notEnoughAsP"));
+        }
+        
+        await this.dsaActor.update({"system.status.astralenergy.value": this.dsaActor.system.status.astralenergy.value - cost});
+        
+        const data = foundry.utils.duplicate(this.message.flags.data);
+        let roll = Roll.fromData(this.originalRoll.toJSON());
+        const d20s = roll.terms.filter(t => t.faces === 20);
+
+        if (this.activeTab === 'reroll') {
+            const rollFormulas = [];
+            for (let i = 0; i < this.selectedForReroll.size; i++) {
+                rollFormulas.push("1d20");
+            }
+            
+            if (rollFormulas.length > 0) {
+                const reroll = await new Roll(rollFormulas.join(" + ")).evaluate();
+                
+                if (game.dice3d) {
+                    await game.dice3d.showForRoll(reroll, game.user, true);
+                }
+                
+                let resultIdx = 0;
+                for (let idx of this.selectedForReroll) {
+                    d20s[idx].results[0].result = reroll.terms[resultIdx * 2].results[0].result;
+                    resultIdx++;
+                }
+            }
+        } else if (this.activeTab === 'addFP') {
+            if (!data.preData.situationalModifiers) data.preData.situationalModifiers = [];
+            data.preData.situationalModifiers.push({ 
+                name: game.i18n.localize("SAVANT.addFP"), 
+                value: this.addedFP, 
+                type: "FP" 
+            });
+        } else if (this.activeTab === 'improve') {
+            this.improvedDice.forEach((val, i) => {
+                d20s[i].results[0].result = val;
+            });
+        }
+        
+        data.preData.roll = roll;
+        const DiceDSA5 = (await import('/systems/dsa5/modules/system/rolls/dice-dsa5.js')).default;
+        await this.dsaActor[data.postData.postFunction]({ testData: data.preData, cardOptions: data }, { rerenderMessage: this.message });
+        await this.message.update({"flags.dsa5.savantUsed": true});
+
+        this.close();
+    }
+}
+
 export default class SavantDSA5 {
     static async handleSavant(message) {
         const data = message.flags.data;
@@ -12,174 +226,32 @@ export default class SavantDSA5 {
     }
 
     static async renderSavantDialog(message, actor, roll) {
-        const data = message.flags.data;
-        const postData = data.postData;
-        const source = postData.source?.system ? postData.source : data.preData.source;
-        const chars = [source.system.characteristic1.value, source.system.characteristic2.value, source.system.characteristic3.value];
-        
-        const dialogData = {
-            description: game.i18n.localize("SAVANT.descriptionSavant"),
-            currentAsP: actor.system.status.astralenergy.value,
-            result: postData.result,
-            qualityStep: postData.qualityStep,
-            dice: roll.terms.filter(t => t.faces === 20).map((t, i) => ({
-                index: i, value: t.results[0].result, attr: chars[i].toLowerCase(),
-                cssClass: t.results[0].result <= postData.characteristics[i].tar ? "suc" : "fail",
-                tooltip: `${game.i18n.localize("CHAR." + chars[i].toUpperCase())} vs ${postData.characteristics[i].tar}`
-            }))
-        };
-
-        const content = await renderTemplate("modules/dsa5-magic-1/templates/savant-dialog.hbs", dialogData);
-        new Dialog({
-            title: game.i18n.localize("SAVANT.name"),
-            content,
-            buttons: {
-                confirm: { label: game.i18n.localize("SAVANT.confirm"), callback: (html) => this._applyChanges(html, message, actor, roll) },
-                cancel: { label: game.i18n.localize("SAVANT.cancel") }
-            },
-            render: (html) => this._activateListeners(html, postData, roll)
-        }).render(true);
-    }
-
-    static _activateListeners(html, postData, roll) {
-        html.find('.item').click(ev => {
-            const tab = $(ev.currentTarget).data('tab');
-            html.find('.item').removeClass('active');
-            $(ev.currentTarget).addClass('active');
-            html.find('.improve-controls, .add-fp-controls').hide();
-            if(tab === 'addFP') html.find('.add-fp-controls').show();
-            else if (tab === 'improve') html.find('.improve-controls').show();
-
-            html.find('.dieButton').removeClass('reroll-selected');
-            html.find('.reroll-checkbox').prop('checked', false);
-
-            const d20s = roll.terms.filter(t => t.faces === 20);
-            html.find('.die-group').each((i, el) => {
-                const originalVal = d20s[i].results[0].result;
-                const target = postData.characteristics[i].tar;
-                const dieSpan = $(el).find('.dieButton span');
-                
-                dieSpan.text(originalVal);
-                dieSpan.removeClass('fail suc').addClass(originalVal <= target ? 'suc' : 'fail');
-            });
-
-            this._updatePreview(html, postData, tab, roll);
-        });
-
-        html.find('.dieButton').click(ev => {
-            if (html.find('.item.active').data('tab') !== 'reroll') return;
-            $(ev.currentTarget).toggleClass('reroll-selected');
-            const checkbox = html.find(`.reroll-checkbox[data-index="${$(ev.currentTarget).data('index')}"]`);
-            checkbox.prop('checked', !checkbox.prop('checked'));
-            this._updatePreview(html, postData, 'reroll', roll);
-        });
-
-        html.find('.fp-input').on('change keyup', () => this._updatePreview(html, postData, 'addFP', roll));
-
-        html.find('.improve-btn').click(ev => {
-            const group = $(ev.currentTarget).closest('.die-group');
-            const index = group.data('index');
-            const dieSpan = group.find('.dieButton span');
-            let val = parseInt(dieSpan.text());
-            const original = roll.terms.filter(t => t.faces === 20)[index].results[0].result;
-            
-            let anotherDieModified = false;
-            html.find('.die-group').each((i, el) => {
-                if (i !== index) {
-                    const currentVal = parseInt($(el).find('.dieButton span').text());
-                    const originalVal = roll.terms.filter(t => t.faces === 20)[i].results[0].result;
-                    if (currentVal < originalVal) anotherDieModified = true;
-                }
-            });
-
-            if (anotherDieModified && $(ev.currentTarget).hasClass('down') && val === original) return;
-
-            if ($(ev.currentTarget).hasClass('up') && val < original) val++;
-            else if ($(ev.currentTarget).hasClass('down') && val > 1) val--;
-            
-            dieSpan.text(val);
-            dieSpan.removeClass('fail suc').addClass(val <= postData.characteristics[index].tar ? 'suc' : 'fail');
-            this._updatePreview(html, postData, 'improve', roll);
-        });
-    }
-
-    static _updatePreview(html, postData, mode, roll) {
-        let cost = 0, modifiedFW = postData.result;
-        if (mode === 'reroll') {
-            if (html.find('.reroll-checkbox:checked').length > 0) cost = 4;
-        } else if (mode === 'addFP') {
-            let added = Math.min(parseInt(html.find('.fp-input').val()) || 0, 18 - postData.result);
-            html.find('.fp-input').val(added);
-            cost = added * 5; modifiedFW += added;
-        } else if (mode === 'improve') {
-            let diffTotal = 0, savedPoints = 0;
-            html.find('.die-group').each((i, el) => {
-                const current = parseInt($(el).find('.dieButton span').text());
-                const original = roll.terms.filter(t => t.faces === 20)[i].results[0].result;
-                const target = postData.characteristics[i].tar;
-                if (original > current) {
-                    diffTotal += (original - current);
-                    savedPoints += (Math.max(0, original - target) - Math.max(0, current - target));
-                }
-            });
-            cost = diffTotal * 2; modifiedFW += savedPoints;
-        }
-        html.find('.asp-cost').text(cost);
-        html.find('.fw-preview').text(modifiedFW);
-        html.find('.qs-preview').text(Math.max(1, Math.min(6, Math.ceil(modifiedFW / 3))));
-    }
-
-    static async _applyChanges(html, message, actor, originalRoll) {
-        const cost = parseInt(html.find('.asp-cost').text());
-        if (actor.system.status.astralenergy.value < cost) return ui.notifications.warn(game.i18n.localize("SAVANT.notEnoughAsP"));
-        
-        await actor.update({"system.status.astralenergy.value": actor.system.status.astralenergy.value - cost});
-        const data = foundry.utils.duplicate(message.flags.data);
-        let roll = Roll.fromData(originalRoll.toJSON());
-        const d20s = roll.terms.filter(t => t.faces === 20);
-
-        const mode = html.find('.item.active').data('tab');
-        if (mode === 'reroll') {
-            const indices = html.find('.reroll-checkbox:checked').map((i, el) => $(el).data('index')).get();
-            for(let idx of indices) d20s[idx].results[0].result = (await new Roll("1d20").evaluate()).total;
-        } else if (mode === 'addFP') {
-            if (!data.preData.situationalModifiers) data.preData.situationalModifiers = [];
-            data.preData.situationalModifiers.push({ name: game.i18n.localize("SAVANT.addFP"), value: parseInt(html.find('.fp-input').val()) || 0, type: "FP" });
-        } else if (mode === 'improve') {
-            html.find('.die-group').each((i, el) => { d20s[i].results[0].result = parseInt($(el).find('.dieButton span').text()); });
-        }
-        
-        data.preData.roll = roll;
-        const DiceDSA5 = (await import('/systems/dsa5/modules/system/rolls/dice-dsa5.js')).default;
-        await actor[data.postData.postFunction]({ testData: data.preData, cardOptions: data }, { rerenderMessage: message });
-        await message.update({"flags.dsa5.savantUsed": true});
+        new SavantApp(message, actor, roll).render(true);
     }
 
     static async _rescueBotch(message, actor) {
         const cost = 10;
-        if (actor.system.status.astralenergy.value < cost) return ui.notifications.warn(game.i18n.localize("SAVANT.notEnoughAsP"));
+        if (actor.system.status.astralenergy.value < cost) {
+            return ui.notifications.warn(game.i18n.localize("SAVANT.notEnoughAsP"));
+        }
         
-        new Dialog({
-            title: game.i18n.localize("SAVANT.name"),
+        const confirmed = await DialogV2.confirm({
+            window: { title: game.i18n.localize("SAVANT.name") },
             content: `<p>${game.i18n.localize("SAVANT.botchRescue")}</p>`,
-            buttons: {
-                yes: {
-                    label: game.i18n.localize("SAVANT.confirm"),
-                    callback: async () => {
-                        await actor.update({"system.status.astralenergy.value": actor.system.status.astralenergy.value - cost});
-                        const failureLabel = game.i18n.localize("Failure");
-                        const updateData = {
-                            "flags.data.postData.successLevel": -1,
-                            "flags.data.postData.description": failureLabel,
-                            "flags.dsa5.savantUsed": true,
-                            "content": message.content.replace(/Patzer|Botch/g, failureLabel)
-                        };
-                        await message.update(updateData);
-                    }
-                },
-                cancel: { label: game.i18n.localize("SAVANT.cancel") }
-            }
-        }).render(true);
+            modal: true
+        });
+
+        if (confirmed) {
+            await actor.update({"system.status.astralenergy.value": actor.system.status.astralenergy.value - cost});
+            const failureLabel = game.i18n.localize("Failure");
+            const updateData = {
+                "flags.data.postData.successLevel": -1,
+                "flags.data.postData.description": failureLabel,
+                "flags.dsa5.savantUsed": true,
+                "content": message.content.replace(/Patzer|Botch/g, failureLabel)
+            };
+            await message.update(updateData);
+        }
     }
 
     static _getRollFromMessage(message) {

--- a/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-init.js
+++ b/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-init.js
@@ -1,0 +1,34 @@
+import SavantDSA5 from './savant-dsa5.js';
+import DSA5_Utility from '/systems/dsa5/modules/system/helpers/utility-dsa5.js';
+
+const getMessageFromLi = (li) => game.messages.get(li.dataset.messageId);
+const getActorFromMessage = (message) => message.speaker?.actor ? game.actors.get(message.speaker.actor) : null;
+
+Hooks.once('init', async function() {
+    await loadTemplates(["modules/dsa5-magic-1/templates/savant-dialog.hbs"]);
+});
+
+Hooks.on('getChatMessageContextOptions', (app, options, c) => {
+    options.push({
+        name: "SAVANT.name",
+        icon: '<i class="fas fa-magic"></i>',
+        condition: (li) => {
+            const el = li[0] || li; 
+            const message = getMessageFromLi(el);
+            const data = message?.flags?.data;
+            if (!data || data.postData?.rollType !== 'talent' || message.flags.dsa5?.savantUsed) return false;
+            if (data.postData.successLevel === -1 || data.postData.successLevel === -3) return false;
+
+            const actor = DSA5_Utility.getSpeaker(message.speaker) || getActorFromMessage(message);
+            if (!actor) return false;
+            
+            const sourceName = data.preData.source.name;
+            const traditionName = game.i18n.localize("SAVANT.tradition");
+
+            return actor.items.some(i => i.type === "specialability" && 
+                i.name.includes(traditionName) && 
+                i.name.includes(sourceName));
+        },
+        callback: (li) => SavantDSA5.handleSavant(getMessageFromLi(li[0] || li))
+    });
+});

--- a/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-init.js
+++ b/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-init.js
@@ -5,13 +5,24 @@ const getMessageFromLi = (li) => game.messages.get(li.dataset.messageId);
 const getActorFromMessage = (message) => message.speaker?.actor ? game.actors.get(message.speaker.actor) : null;
 
 Hooks.once('init', async function() {
+    const styleId = "savant-styles";
+    if (!document.getElementById(styleId)) {
+        document.head.insertAdjacentHTML("beforeend", `
+            <style id="${styleId}">
+                .savant-dialog .dieButton { border: 2px solid transparent; border-radius: 5px; padding: 2px; transition: all 0.2s ease; display: inline-block; cursor: pointer; }
+                .savant-dialog .dieButton.reroll-selected { border-color: #004a99; box-shadow: 0 0 10px #0073e6; background-color: rgba(0, 115, 230, 0.1); }
+                .savant-dialog .die-group { min-width: 60px; }
+            </style>
+        `);
+    }
+
     await loadTemplates(["modules/dsa5-magic-1/templates/savant-dialog.hbs"]);
 });
 
 Hooks.on('getChatMessageContextOptions', (app, options, c) => {
     options.push({
         name: "SAVANT.name",
-         icon: '<img src="systems/dsa5/icons/traditionen/magiedilettanten.webp" style="width: 10px; height: 10px; display: inline-block; vertical-align: middle; margin-left: 2px; margin-right: 10px; border: none; margin-bottom: 0;">',
+        icon: '<img src="systems/dsa5/icons/traditionen/magiedilettanten.webp" style="width: 10px; height: 10px; display: inline-block; vertical-align: middle; margin-left: 2px; margin-right: 10px; border: none; margin-bottom: 0;">',
         condition: (li) => {
             const el = li[0] || li; 
             const message = getMessageFromLi(el);

--- a/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-init.js
+++ b/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-init.js
@@ -11,7 +11,7 @@ Hooks.once('init', async function() {
 Hooks.on('getChatMessageContextOptions', (app, options, c) => {
     options.push({
         name: "SAVANT.name",
-        icon: '<i class="fas fa-magic"></i>',
+         icon: '<img src="systems/dsa5/icons/traditionen/magiedilettanten.webp" style="width: 10px; height: 10px; display: inline-block; vertical-align: middle; margin-left: 2px; margin-right: 10px; border: none; margin-bottom: 0;">',
         condition: (li) => {
             const el = li[0] || li; 
             const message = getMessageFromLi(el);

--- a/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-init.js
+++ b/macros/skill/Data/modules/dsa5-magic-1/scripts/savant-init.js
@@ -5,24 +5,13 @@ const getMessageFromLi = (li) => game.messages.get(li.dataset.messageId);
 const getActorFromMessage = (message) => message.speaker?.actor ? game.actors.get(message.speaker.actor) : null;
 
 Hooks.once('init', async function() {
-    const styleId = "savant-styles";
-    if (!document.getElementById(styleId)) {
-        document.head.insertAdjacentHTML("beforeend", `
-            <style id="${styleId}">
-                .savant-dialog .dieButton { border: 2px solid transparent; border-radius: 5px; padding: 2px; transition: all 0.2s ease; display: inline-block; cursor: pointer; }
-                .savant-dialog .dieButton.reroll-selected { border-color: #004a99; box-shadow: 0 0 10px #0073e6; background-color: rgba(0, 115, 230, 0.1); }
-                .savant-dialog .die-group { min-width: 60px; }
-            </style>
-        `);
-    }
-
     await loadTemplates(["modules/dsa5-magic-1/templates/savant-dialog.hbs"]);
 });
 
 Hooks.on('getChatMessageContextOptions', (app, options, c) => {
     options.push({
         name: "SAVANT.name",
-        icon: '<img src="systems/dsa5/icons/traditionen/magiedilettanten.webp" style="width: 10px; height: 10px; display: inline-block; vertical-align: middle; margin-left: 2px; margin-right: 10px; border: none; margin-bottom: 0;">',
+        icon: '<img src="systems/dsa5/icons/traditionen/magiedilettanten.webp" class="magictradition-context-icon">',
         condition: (li) => {
             const el = li[0] || li; 
             const message = getMessageFromLi(el);

--- a/macros/skill/Data/modules/dsa5-magic-1/templates/savant-dialog.hbs
+++ b/macros/skill/Data/modules/dsa5-magic-1/templates/savant-dialog.hbs
@@ -1,4 +1,4 @@
-<<style>
+<style>
     .savant-dialog .dieButton { border: 2px solid transparent; border-radius: 5px; padding: 2px; transition: all 0.2s ease; display: inline-block; }
     .savant-dialog .dieButton.reroll-selected { border-color: #004a99; box-shadow: 0 0 10px #0073e6; background-color: rgba(0, 115, 230, 0.1); }
     .savant-dialog .die-group { min-width: 60px; }

--- a/macros/skill/Data/modules/dsa5-magic-1/templates/savant-dialog.hbs
+++ b/macros/skill/Data/modules/dsa5-magic-1/templates/savant-dialog.hbs
@@ -1,43 +1,61 @@
-<style>
-    .savant-dialog .dieButton { border: 2px solid transparent; border-radius: 5px; padding: 2px; transition: all 0.2s ease; display: inline-block; }
-    .savant-dialog .dieButton.reroll-selected { border-color: #004a99; box-shadow: 0 0 10px #0073e6; background-color: rgba(0, 115, 230, 0.1); }
-    .savant-dialog .die-group { min-width: 60px; }
-</style>
-
-<div class="savant-dialog">
+<div class="savant-dialog" style="height: 100%; overflow-y: auto; padding-right: 5px; box-sizing: border-box;">
     <div class="description">{{{description}}}</div>
     <hr>
-    <nav class="sheet-tabs tabs" data-group="primary">
-        <a class="item active" data-tab="reroll">{{localize "SAVANT.reroll"}}</a>
-        <a class="item" data-tab="addFP">{{localize "SAVANT.addFP"}}</a>
-        <a class="item" data-tab="improve">{{localize "SAVANT.improveRoll"}}</a>
+    
+    <nav class="sheet-tabs tabs" style="display:flex; border-bottom: 1px solid #777; margin-bottom: 10px;">
+        <a class="item {{#if isRerollTab}}active{{/if}}" data-action="switchTab" data-tab="reroll" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SAVANT.reroll"}}</a>
+        <a class="item {{#if isAddFPTab}}active{{/if}}" data-action="switchTab" data-tab="addFP" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SAVANT.addFP"}}</a>
+        <a class="item {{#if isImproveTab}}active{{/if}}" data-action="switchTab" data-tab="improve" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SAVANT.improveRoll"}}</a>
     </nav>
+    
     <section class="content" style="padding: 10px 0;">
-        <div class="dice-display" style="display: flex; justify-content: center; margin-bottom: 10px; gap: 10px;">
-            {{#each dice as |die|}}
-            <div class="die-group" data-index="{{die.index}}" style="text-align: center; display: flex; flex-direction: column; align-items: center;">
-                <input type="checkbox" class="reroll-checkbox" data-index="{{die.index}}" style="display:none;">
-                <a class="dieButton" data-index="{{die.index}}">
-                    <span data-tooltip="{{die.tooltip}}" class="{{die.cssClass}} die-{{die.attr}} d20">{{die.value}}</span>
-                </a>
-                <div class="improve-controls" style="display:none; margin-top: 5px;">
-                    <a class="improve-btn up" style="cursor:pointer;"><i class="fas fa-chevron-up"></i></a>
-                    <a class="improve-btn down" style="cursor:pointer;"><i class="fas fa-chevron-down"></i></a>
+        <div style="display: flex; flex-direction: row; align-items: center; gap: 20px;">
+            
+            <div class="result-preview" style="flex: 0 0 auto; padding-right: 20px;">
+                <div><strong>{{localize "SAVANT.skillValuePreview"}}:</strong> <span class="fw-preview">{{previewFW}}</span></div>
+                <div><strong>{{localize "SAVANT.qsPreview"}}:</strong> <span class="qs-preview">{{previewQS}}</span></div>
+                <div style="color: darkred;"><strong>{{localize "SAVANT.cost"}}:</strong> <span class="asp-cost">{{cost}}</span> {{localize "SAVANT.aspUnit"}}</div>
+                <div><strong>{{localize "SAVANT.currentAsP"}}:</strong> {{currentAsP}}</div>
+            </div>
+
+            <div style="flex: 1 1 auto; display: flex; flex-direction: column; align-items: center;">
+                
+                <div class="dice-display" style="display: flex; justify-content: center; gap: 10px;">
+                    {{#each dice as |die|}}
+                    <div class="die-group" data-index="{{die.index}}" style="text-align: center; display: flex; flex-direction: column; align-items: center;">
+                        <a class="dieButton {{#if die.selected}}reroll-selected{{/if}}" data-action="toggleDie" data-index="{{die.index}}">
+                            <span data-tooltip="{{die.tooltip}}" class="{{die.cssClass}} die-{{die.attr}} d20">{{die.currentValue}}</span>
+                        </a>
+                        
+                        {{#if ../isImproveTab}}
+                        <div class="improve-controls" style="margin-top: 5px;">
+                            <a class="improve-btn up" data-action="adjustDie" data-delta="1" data-index="{{die.index}}" style="cursor:pointer;"><i class="fas fa-chevron-up"></i></a>
+                            <a class="improve-btn down" data-action="adjustDie" data-delta="-1" data-index="{{die.index}}" style="cursor:pointer;"><i class="fas fa-chevron-down"></i></a>
+                        </div>
+                        {{/if}}
+                    </div>
+                    {{/each}}
                 </div>
+                
+                {{#if isAddFPTab}}
+                <div class="add-fp-controls" style="text-align: center; margin-top: 15px;">
+                    <div style="display: flex; justify-content: center; align-items: center;">
+                        <label style="margin-right: 10px;">{{localize "MODS.FW"}}: </label>
+                        <div style="display: flex; flex-direction: column; align-items: center;">
+                            <a data-action="adjustFP" data-delta="1" style="cursor:pointer;"><i class="fas fa-chevron-up"></i></a>
+                            <input type="number" class="fp-input" value="{{addedFP}}" readonly style="width: 50px; text-align: center; height: 30px; border: 1px solid #7a7971;">
+                            <a data-action="adjustFP" data-delta="-1" style="cursor:pointer;"><i class="fas fa-chevron-down"></i></a>
+                        </div>
+                    </div>
+                </div>
+                {{/if}}
+
             </div>
-            {{/each}}
-        </div>
-        <div class="add-fp-controls" style="display:none; text-align: center;">
-            <div style="display: flex; justify-content: center; align-items: center;">
-                <label style="margin-right: 10px;">{{localize "MODS.FW"}}: </label>
-                <input type="number" class="fp-input" value="0" min="0" style="width: 50px; text-align: center;">
-            </div>
-        </div>
-        <div class="result-preview" style="margin-top: 15px; border-top: 1px solid #ccc; padding-top: 5px;">
-            <div><strong>{{localize "SAVANT.skillValuePreview"}}:</strong> <span class="fw-preview">{{result}}</span></div>
-            <div><strong>{{localize "SAVANT.qsPreview"}}:</strong> <span class="qs-preview">{{qualityStep}}</span></div>
-            <div style="color: darkred;"><strong>{{localize "SAVANT.cost"}}:</strong> <span class="asp-cost">0</span> {{localize "SAVANT.aspUnit"}}</div>
-            <div><strong>{{localize "SAVANT.currentAsP"}}:</strong> {{currentAsP}}</div>
         </div>
     </section>
+    
+    <footer class="form-footer" style="display: flex; gap: 5px; margin-top: 15px;">
+        <button type="button" data-action="confirm" class="dsa5 button" style="flex:1"><i class="fas fa-check"></i> {{localize "SAVANT.confirm"}}</button>
+        <button type="button" data-action="cancel" class="dsa5 button" style="flex:1"><i class="fas fa-times"></i> {{localize "SAVANT.cancel"}}</button>
+    </footer>
 </div>

--- a/macros/skill/Data/modules/dsa5-magic-1/templates/savant-dialog.hbs
+++ b/macros/skill/Data/modules/dsa5-magic-1/templates/savant-dialog.hbs
@@ -1,0 +1,43 @@
+<<style>
+    .savant-dialog .dieButton { border: 2px solid transparent; border-radius: 5px; padding: 2px; transition: all 0.2s ease; display: inline-block; }
+    .savant-dialog .dieButton.reroll-selected { border-color: #004a99; box-shadow: 0 0 10px #0073e6; background-color: rgba(0, 115, 230, 0.1); }
+    .savant-dialog .die-group { min-width: 60px; }
+</style>
+
+<div class="savant-dialog">
+    <div class="description">{{{description}}}</div>
+    <hr>
+    <nav class="sheet-tabs tabs" data-group="primary">
+        <a class="item active" data-tab="reroll">{{localize "SAVANT.reroll"}}</a>
+        <a class="item" data-tab="addFP">{{localize "SAVANT.addFP"}}</a>
+        <a class="item" data-tab="improve">{{localize "SAVANT.improveRoll"}}</a>
+    </nav>
+    <section class="content" style="padding: 10px 0;">
+        <div class="dice-display" style="display: flex; justify-content: center; margin-bottom: 10px; gap: 10px;">
+            {{#each dice as |die|}}
+            <div class="die-group" data-index="{{die.index}}" style="text-align: center; display: flex; flex-direction: column; align-items: center;">
+                <input type="checkbox" class="reroll-checkbox" data-index="{{die.index}}" style="display:none;">
+                <a class="dieButton" data-index="{{die.index}}">
+                    <span data-tooltip="{{die.tooltip}}" class="{{die.cssClass}} die-{{die.attr}} d20">{{die.value}}</span>
+                </a>
+                <div class="improve-controls" style="display:none; margin-top: 5px;">
+                    <a class="improve-btn up" style="cursor:pointer;"><i class="fas fa-chevron-up"></i></a>
+                    <a class="improve-btn down" style="cursor:pointer;"><i class="fas fa-chevron-down"></i></a>
+                </div>
+            </div>
+            {{/each}}
+        </div>
+        <div class="add-fp-controls" style="display:none; text-align: center;">
+            <div style="display: flex; justify-content: center; align-items: center;">
+                <label style="margin-right: 10px;">{{localize "MODS.FW"}}: </label>
+                <input type="number" class="fp-input" value="0" min="0" style="width: 50px; text-align: center;">
+            </div>
+        </div>
+        <div class="result-preview" style="margin-top: 15px; border-top: 1px solid #ccc; padding-top: 5px;">
+            <div><strong>{{localize "SAVANT.skillValuePreview"}}:</strong> <span class="fw-preview">{{result}}</span></div>
+            <div><strong>{{localize "SAVANT.qsPreview"}}:</strong> <span class="qs-preview">{{qualityStep}}</span></div>
+            <div style="color: darkred;"><strong>{{localize "SAVANT.cost"}}:</strong> <span class="asp-cost">0</span> {{localize "SAVANT.aspUnit"}}</div>
+            <div><strong>{{localize "SAVANT.currentAsP"}}:</strong> {{currentAsP}}</div>
+        </div>
+    </section>
+</div>

--- a/macros/skill/Data/modules/dsa5-magic-1/templates/savant-dialog.hbs
+++ b/macros/skill/Data/modules/dsa5-magic-1/templates/savant-dialog.hbs
@@ -1,36 +1,54 @@
-<div class="savant-dialog" style="height: 100%; overflow-y: auto; padding-right: 5px; box-sizing: border-box;">
-    <div class="description">{{{description}}}</div>
+<div class="savant-dialog scrollable" style="padding-right: 5px;">
+    
+    <div class="description">
+        <strong>{{localize "SAVANT.descTitle"}}</strong>
+        
+        <div class="magictradition-opt-row">
+            <i class="fas fa-dsa5 magictradition-opt-icon"></i>
+            <div>{{localize "SAVANT.descOpt1"}}</div>
+        </div>
+        
+        <div class="magictradition-opt-row">
+            <i class="fas fa-dsa5 magictradition-opt-icon"></i>
+            <div>{{localize "SAVANT.descOpt2"}}</div>
+        </div>
+        
+        <div class="magictradition-opt-row">
+            <i class="fas fa-dsa5 magictradition-opt-icon"></i>
+            <div>{{localize "SAVANT.descOpt3"}}</div>
+        </div>
+    </div>
     <hr>
     
-    <nav class="sheet-tabs tabs" style="display:flex; border-bottom: 1px solid #777; margin-bottom: 10px;">
-        <a class="item {{#if isRerollTab}}active{{/if}}" data-action="switchTab" data-tab="reroll" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SAVANT.reroll"}}</a>
-        <a class="item {{#if isAddFPTab}}active{{/if}}" data-action="switchTab" data-tab="addFP" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SAVANT.addFP"}}</a>
-        <a class="item {{#if isImproveTab}}active{{/if}}" data-action="switchTab" data-tab="improve" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SAVANT.improveRoll"}}</a>
+    <nav class="sheet-tabs tabs marginBottom">
+        <a class="item tabelement {{#if isRerollTab}}active{{/if}}" data-action="switchTab" data-tab="reroll">{{localize "SAVANT.reroll"}}</a>
+        <a class="item tabelement {{#if isAddFPTab}}active{{/if}}" data-action="switchTab" data-tab="addFP">{{localize "SAVANT.addFP"}}</a>
+        <a class="item tabelement {{#if isImproveTab}}active{{/if}}" data-action="switchTab" data-tab="improve">{{localize "SAVANT.improveRoll"}}</a>
     </nav>
     
-    <section class="content" style="padding: 10px 0;">
-        <div style="display: flex; flex-direction: row; align-items: center; gap: 20px;">
+    <section class="content">
+        <div class="row-section flexgap" style="align-items: flex-start;">
             
-            <div class="result-preview" style="flex: 0 0 auto; padding-right: 20px;">
+            <div class="result-preview" style="flex: 0 0 auto;">
                 <div><strong>{{localize "SAVANT.skillValuePreview"}}:</strong> <span class="fw-preview">{{previewFW}}</span></div>
                 <div><strong>{{localize "SAVANT.qsPreview"}}:</strong> <span class="qs-preview">{{previewQS}}</span></div>
                 <div style="color: darkred;"><strong>{{localize "SAVANT.cost"}}:</strong> <span class="asp-cost">{{cost}}</span> {{localize "SAVANT.aspUnit"}}</div>
                 <div><strong>{{localize "SAVANT.currentAsP"}}:</strong> {{currentAsP}}</div>
             </div>
 
-            <div style="flex: 1 1 auto; display: flex; flex-direction: column; align-items: center;">
+            <div class="columnFlex center" style="flex: 1 1 auto; align-items: center;">
                 
-                <div class="dice-display" style="display: flex; justify-content: center; gap: 10px;">
+                <div class="dice-display row-section gap10px center" style="justify-content: center;">
                     {{#each dice as |die|}}
-                    <div class="die-group" data-index="{{die.index}}" style="text-align: center; display: flex; flex-direction: column; align-items: center;">
-                        <a class="dieButton {{#if die.selected}}reroll-selected{{/if}}" data-action="toggleDie" data-index="{{die.index}}">
+                    <div class="die-group columnFlex center" data-index="{{die.index}}" style="align-items: center;">
+                        <a class="dieButton {{#if die.selected}}dieSelected{{/if}}" data-action="toggleDie" data-index="{{die.index}}">
                             <span data-tooltip="{{die.tooltip}}" class="{{die.cssClass}} die-{{die.attr}} d20">{{die.currentValue}}</span>
                         </a>
                         
                         {{#if ../isImproveTab}}
-                        <div class="improve-controls" style="margin-top: 5px;">
-                            <a class="improve-btn up" data-action="adjustDie" data-delta="1" data-index="{{die.index}}" style="cursor:pointer;"><i class="fas fa-chevron-up"></i></a>
-                            <a class="improve-btn down" data-action="adjustDie" data-delta="-1" data-index="{{die.index}}" style="cursor:pointer;"><i class="fas fa-chevron-down"></i></a>
+                        <div class="improve-controls columnFlex center" style="margin-top: 5px;">
+                            <a class="improve-btn up" data-action="adjustDie" data-delta="1" data-index="{{die.index}}"><i class="fas fa-chevron-up"></i></a>
+                            <a class="improve-btn down" data-action="adjustDie" data-delta="-1" data-index="{{die.index}}"><i class="fas fa-chevron-down"></i></a>
                         </div>
                         {{/if}}
                     </div>
@@ -38,13 +56,13 @@
                 </div>
                 
                 {{#if isAddFPTab}}
-                <div class="add-fp-controls" style="text-align: center; margin-top: 15px;">
-                    <div style="display: flex; justify-content: center; align-items: center;">
+                <div class="add-fp-controls center" style="margin-top: 15px; width: 100%;">
+                    <div class="row-section center" style="align-items: center; justify-content: center;">
                         <label style="margin-right: 10px;">{{localize "MODS.FW"}}: </label>
-                        <div style="display: flex; flex-direction: column; align-items: center;">
-                            <a data-action="adjustFP" data-delta="1" style="cursor:pointer;"><i class="fas fa-chevron-up"></i></a>
-                            <input type="number" class="fp-input" value="{{addedFP}}" readonly style="width: 50px; text-align: center; height: 30px; border: 1px solid #7a7971;">
-                            <a data-action="adjustFP" data-delta="-1" style="cursor:pointer;"><i class="fas fa-chevron-down"></i></a>
+                        <div class="columnFlex center" style="align-items: center;">
+                            <a data-action="adjustFP" data-delta="1"><i class="fas fa-chevron-up"></i></a>
+                            <input type="number" class="fp-input input-text" value="{{addedFP}}" readonly style="width: 50px; text-align: center;">
+                            <a data-action="adjustFP" data-delta="-1"><i class="fas fa-chevron-down"></i></a>
                         </div>
                     </div>
                 </div>
@@ -54,8 +72,8 @@
         </div>
     </section>
     
-    <footer class="form-footer" style="display: flex; gap: 5px; margin-top: 15px;">
-        <button type="button" data-action="confirm" class="dsa5 button" style="flex:1"><i class="fas fa-check"></i> {{localize "SAVANT.confirm"}}</button>
-        <button type="button" data-action="cancel" class="dsa5 button" style="flex:1"><i class="fas fa-times"></i> {{localize "SAVANT.cancel"}}</button>
+    <footer class="row-section gap5px" style="margin-top: 15px;">
+        <button type="button" data-action="confirm" class="col two dsa5 button"><i class="fas fa-check"></i> {{localize "SAVANT.confirm"}}</button>
+        <button type="button" data-action="cancel" class="col two dsa5 button"><i class="fas fa-times"></i> {{localize "SAVANT.cancel"}}</button>
     </footer>
 </div>


### PR DESCRIPTION
CSS (siehe auch [Magical Alchemist](https://github.com/Plushtoast/dsa5-extensiondb/pull/128):

```
.magictradition-opt-row {
    display: flex;
    align-items: flex-start;
    margin-top: 10px;
}
.magictradition-opt-icon {
    width: 18px !important;
    height: 18px !important;
    flex: 0 0 18px;
    margin-right: 8px;
    margin-top: 2px;
}
.magictradition-context-icon {
    width: 10px !important;
    height: 10px !important;
    display: inline-block;
    vertical-align: middle;
    margin-left: 2px;
    margin-right: 10px;
    border: none !important;
    margin-bottom: 0;
}
```

Verwendete Icons:

[fas fa-chevron-down](https://fontawesome.com/icons/chevron-down?f=classic&s=solid)
[fas fa-chevron-up](https://fontawesome.com/icons/chevron-up?f=classic&s=solid)

Überarbeitete Version von https://github.com/Plushtoast/dsa5-foundryVTT/pull/2170

Benötigt erweiterung der lang-files und Registrierung der Datei unter module.json.
```
"SAVANT": {
    "name": "Meistertalentierte",
    "tradition": "Tradition (Meistertalentierte)",
    "botchRescue": "Möchtest du den Patzer in einen Misserfolg umwandeln? (10 AsP)",
    "notEnoughAsP": "Nicht genügend AsP vorhanden.",
    "reroll": "Neu Würfeln",
    "addFP": "Talentpunkte hinzugewinnen",
    "improveRoll": "Wurf verbessern",
    "confirm": "Bestätigen",
    "cancel": "Abbrechen",
    "cost": "Kosten",
    "currentAsP": "Aktuelle AsP",
    "aspUnit": "AsP",
    "skillValuePreview": "Fähigkeitswert",
    "qsPreview": "Qualitätsstufe",
    "descTitle": "Optionen für das Meistertalent:",
        "descOpt1": "Bei einer gelungenen Probe auf ihr Meistertalent können Meistertalentierte AsP einsetzen, um das Ergebnis zu verbessern. Pro 5 AsP kann 1 FP hinzugewonnen werden (bis zu einem Maximum von insgesamt 18 FP).",
        "descOpt2": "Ein Meistertalentierter kann bei einer Sammelprobe auf das Meistertalent bei einem einzigen Durchgang bis zu drei W20 neu würfeln, so wie unter dem Schicksalspunkte-Einsatz Neuer Wurf angegeben. Dies kostet 4 AsP. Dies gilt nur für den Wurf einer der möglichen Würfe von Sammelproben. Bei einem neuen Intervall müssen erneut AsP eingesetzt werden, um den gleichen Effekt zu erzielen.",
        "descOpt3": "Der Meistertalentierte kann das Ergebnis eines 1W20-Wurfs bei einer Teilprobe auf sein Meistertalent um 1 senken, um somit ein besseres Ergebnis zu erzielen. Dazu muss er 2 AsP ausgeben. Er darf jedoch keine solche Änderung vornehmen, um einen Kritischen Erfolg (also eine Doppel- oder Dreifach-1) zu erzielen oder einen Patzer zu verhindern."
}
```

```
"SAVANT": {
        "name": "Savant",
	"tradition": "Tradition (Savant)",
        "botchRescue": "Do you want to turn the Botch into a Failure? (10 AE)",
        "notEnoughAsP": "Not enough AE available.",
        "reroll": "Reroll",
        "addFP": "Add Skill Points (SP)",
        "improveRoll": "Improve Roll",
        "confirm": "Confirm",
        "cancel": "Cancel",
        "cost": "Cost",
        "currentAsP": "Current AE",
        "aspUnit": "AE",
        "skillValuePreview": "Skill Value",
        "qsPreview": "Quality Level",
        "descTitle": "Master Skill Options:",
        "descOpt1": "Upon a successful check on their Master Skill, Savants can spend AE to improve the result. For every 5 AE spent, 1 SP can be gained (up to a maximum total of 18 SP).",
        "descOpt2": "During a Cumulative Check on the Master Skill, a Savant can reroll up to three d20s for a single roll, functioning like the Fate Point application Reroll. This costs 4 AE. This only applies to one of the possible rolls of a Cumulative Check. For a new interval, AE must be spent again to achieve the same effect.",
        "descOpt3": "The Savant can lower the result of a 1d20 roll during a partial check on their Master Skill by 1 to achieve a better result. This requires spending 2 AE. However, this alteration cannot be used to achieve a Critical Success (a double or triple 1) or to prevent a Botch."
    }
```

Damit das System erkennt, ob ein Charakter die Berechtigung hat, eine Probe zu modifizieren, müssen die Sonderfertigkeiten exakt benannt sein. Das Skript prüft, ob der Name der Sonderfertigkeit sowohl den Namen der Tradition als auch den Namen des gewürfelten Talents enthält.

Meine Empfehlung: Zieht ein Spieler "Tradition (Meistertalentierte)" ins Charactersheet öffnet sich, wie bereits bei anderen Vorteilen usw, ein GUI, welches abfragt, um welches Talent es sich handelt. Dadurch wird dann (>>Talentname<<) ausgefüllt. Das ist aber noch nicht hier mit eingebaut.

Format: Tradition (Meistertalentierte) (Talentname)
