### PR TITLE
Supporting Skill Test (Core)

### DIFF
--- a/macros/skill/Supporting_Talent_Test.js
+++ b/macros/skill/Supporting_Talent_Test.js
@@ -86,7 +86,6 @@ Hooks.on('dsa5.getRollDialogContextOptions', (dialogState, menuItems) => {
             const modifierLabel = game.i18n.localize("SUPPORTING_TEST.modifierLabel");
             if (checkModifierApplied(parentDialog.element, modifierLabel)) {
                 ui.notifications.warn(game.i18n.localize("SUPPORTING_TEST.alreadyApplied"));
-                console.error("DEBUG | Abbruch: Unterstützung bereits vorhanden.");
                 return;
             }
 

--- a/macros/skill/Supporting_Talent_Test.js
+++ b/macros/skill/Supporting_Talent_Test.js
@@ -82,7 +82,7 @@ Hooks.on('dsa5.getRollDialogContextOptions', (dialogState, menuItems) => {
         name: game.i18n.localize("SUPPORTING_TEST.menuLabel"),
         icon: '<i class="fas fa-hands-helping"></i>',
         callback: async () => {
-            // --- NEU: Vor dem Öffnen prüfen, ob der Bonus schon im Fenster ist ---
+            // Vor dem Öffnen prüfen, ob der Bonus schon im Fenster ist
             const modifierLabel = game.i18n.localize("SUPPORTING_TEST.modifierLabel");
             if (checkModifierApplied(parentDialog.element, modifierLabel)) {
                 ui.notifications.warn(game.i18n.localize("SUPPORTING_TEST.alreadyApplied"));

--- a/macros/skill/Supporting_Talent_Test.js
+++ b/macros/skill/Supporting_Talent_Test.js
@@ -57,22 +57,32 @@ function injectSupportingModifier(targetDialog, value, tooltip, displayLabel) {
 }
 
 const SUPPORT_TEMPLATE_STRING = `
-<div style="margin-bottom: 10px; font-style: italic; font-size: 0.95em; padding: 8px; background: rgba(0,0,0,0.05); line-height: 1.3;">
-    {{localize "SUPPORTING_TEST.description"}}
+<div class="marginBottom">
+    <p class="center"><i>{{localize "SUPPORTING_TEST.description"}}</i></p>
 </div>
-<nav class="sheet-tabs tabs" style="display:flex; border-bottom: 1px solid #777; margin-bottom: 10px;">
-    {{#each groups}}
-    <a class="item {{#if this.active}}active{{/if}}" data-action="switchTab" data-tab="{{this.id}}" style="flex:1; text-align:center; padding: 5px; cursor:pointer; font-weight: {{#if this.active}}bold{{else}}normal{{/if}};">{{this.label}}</a>
+
+<nav class="sheet-tabs tabs">
+    {{#each topGroups}}
+    <a class="item tabelement {{#if this.active}}active{{/if}}" data-action="switchTab" data-tab="{{this.id}}">{{this.label}}</a>
     {{/each}}
 </nav>
-<section class="content supporting-test-content" style="max-height: 400px; overflow-y: auto; padding: 5px;">
-    {{#each groups}}
+
+<nav class="sheet-tabs tabs marginBottom">
+    {{#each bottomGroups}}
+    <a class="item tabelement {{#if this.active}}active{{/if}}" data-action="switchTab" data-tab="{{this.id}}">{{this.label}}</a>
+    {{/each}}
+</nav>
+
+<section class="content scrollable supporting-test-content">
+    {{#each allGroups}}
     <div class="tab {{this.id}} {{#if this.active}}active{{/if}}" style="display: {{#if this.active}}block{{else}}none{{/if}};">
-        <div class="form-group knowledge-buttons" style="display: grid; grid-template-columns: 1fr 1fr; gap: 5px;">
+        
+        <div class="dsa-skill-grid-3x2">
             {{#each this.talents}}
-            <button type="button" class="support-roll-btn dsa5 button" data-action="rollSupport" data-id="{{this.id}}" style="font-size: 1.1em; height: auto; padding: 5px;">{{this.name}}</button>
+            <button type="button" class="dsa5 button support-roll-btn" data-action="rollSupport" data-id="{{this.id}}" data-tooltip="{{this.name}}">{{this.name}}</button>
             {{/each}}
         </div>
+
     </div>
     {{/each}}
 </section>
@@ -83,12 +93,13 @@ const { ApplicationV2 } = foundry.applications.api;
 class SupportingTestApp extends ApplicationV2 {
     static DEFAULT_OPTIONS = {
         id: "supporting-test-app",
+        classes: ["dsa5"],
         window: {
             resizable: true 
         },
         position: {
-            width: 705,
-            height: 575
+            width: 565,
+            height: 520 
         },
         actions: {
             switchTab: function(event, target) { this._onSwitchTab(event, target); },
@@ -120,14 +131,16 @@ class SupportingTestApp extends ApplicationV2 {
         const prepare = (l) => l.map(i => ({ id: i.id || i._id, name: i.name })).sort((a, b) => a.name.localeCompare(b.name));
         const talents = this.dsaActor.items.filter(i => i.type === "skill");
         
+        const body = { id: "body", label: game.i18n.localize("SKILL.body"), active: this.activeTab === "body", talents: prepare(talents.filter(i => i.system.group?.value === "body")) };
+        const social = { id: "social", label: game.i18n.localize("SKILL.social"), active: this.activeTab === "social", talents: prepare(talents.filter(i => i.system.group?.value === "social")) };
+        const nature = { id: "nature", label: game.i18n.localize("SKILL.nature"), active: this.activeTab === "nature", talents: prepare(talents.filter(i => i.system.group?.value === "nature")) };
+        const knowledge = { id: "knowledge", label: game.i18n.localize("SKILL.knowledge"), active: this.activeTab === "knowledge", talents: prepare(talents.filter(i => i.system.group?.value === "knowledge")) };
+        const trade = { id: "trade", label: game.i18n.localize("SKILL.trade"), active: this.activeTab === "trade", talents: prepare(talents.filter(i => i.system.group?.value === "trade")) };
+        
         return {
-            groups: [
-                { id: "body", label: game.i18n.localize("SKILL.body"), active: this.activeTab === "body", talents: prepare(talents.filter(i => i.system.group?.value === "body")) },
-                { id: "social", label: game.i18n.localize("SKILL.social"), active: this.activeTab === "social", talents: prepare(talents.filter(i => i.system.group?.value === "social")) },
-                { id: "nature", label: game.i18n.localize("SKILL.nature"), active: this.activeTab === "nature", talents: prepare(talents.filter(i => i.system.group?.value === "nature")) },
-                { id: "knowledge", label: game.i18n.localize("SKILL.knowledge"), active: this.activeTab === "knowledge", talents: prepare(talents.filter(i => i.system.group?.value === "knowledge")) },
-                { id: "trade", label: game.i18n.localize("SKILL.trade"), active: this.activeTab === "trade", talents: prepare(talents.filter(i => i.system.group?.value === "trade")) }
-            ]
+            topGroups: [body, social, nature],
+            bottomGroups: [knowledge, trade],
+            allGroups: [body, social, nature, knowledge, trade]
         };
     }
     

--- a/macros/skill/Supporting_Talent_Test.js
+++ b/macros/skill/Supporting_Talent_Test.js
@@ -1,0 +1,144 @@
+/**
+ * SUPPORTING_CHECK.js
+ * Inklusive Überprüfung auf bereits vorhandene Boni.
+ */
+
+console.error("%c >>> SUPPORT-SCRIPT: AKTIVIERT (Inkl. Dubletten-Check) <<< ", "background: #800; color: #fff; font-size: 14px;");
+
+// --- NEU: Hilfsfunktion zur Überprüfung des DOM ---
+function checkModifierApplied(dialogHtml, searchString) {
+    return $(dialogHtml).find('select[name="situationalModifiers"] option').filter(function() {
+        return $(this).text().includes(searchString);
+    }).length > 0;
+}
+
+const SUPPORT_TEMPLATE_STRING = `
+<div style="margin-bottom: 10px; font-style: italic; font-size: 0.95em; padding: 8px; border-left: 3px solid #7a7971; background: rgba(0,0,0,0.05); line-height: 1.3;">
+    {{localize "SUPPORTING_TEST.description"}}
+</div>
+<nav class="sheet-tabs tabs" data-group="primary" style="display:flex; border-bottom: 1px solid #777; margin-bottom: 10px;">
+    <a class="item active" data-tab="body" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.physical"}}</a>
+    <a class="item" data-tab="social" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.social"}}</a>
+    <a class="item" data-tab="nature" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.nature"}}</a>
+    <a class="item" data-tab="knowledge" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.knowledge"}}</a>
+    <a class="item" data-tab="trade" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.trade"}}</a>
+</nav>
+<section class="content supporting-test-content" style="max-height: 400px; overflow-y: auto; padding: 5px;">
+    {{#each groups as |talents groupName|}}
+    <div class="tab {{groupName}} {{#if (eq groupName 'body')}}active{{/if}}" data-tab="{{groupName}}" style="display: {{#if (eq groupName 'body')}}block{{else}}none{{/if}};">
+        <div class="form-group knowledge-buttons" style="display: grid; grid-template-columns: 1fr 1fr; gap: 5px;">
+            {{#each talents}}
+            <button class="support-roll-btn dsa5 button" data-id="{{this.id}}" style="font-size: 1.1em; height: auto; padding: 5px;">{{this.name}}</button>
+            {{/each}}
+        </div>
+    </div>
+    {{/each}}
+</section>
+`;
+
+function injectSupportingModifier(targetDialog, value, tooltip, displayLabel) {
+    const html = $(targetDialog.element);
+    let modifierContainer = html.find('.modifiers');
+
+    if (modifierContainer.length === 0) {
+        const finalLabel = game.i18n.localize("situationalModifiers") === "situationalModifiers" ? "Bedingte Modifikatoren" : game.i18n.localize("situationalModifiers");
+
+        const fieldHtml = `
+            <div class="modifiers form-group" style="flex-grow: 1;">
+                <label>${finalLabel}</label>
+                <div class="form-fields height100">
+                    <select name="situationalModifiers" multiple="" class="height100">
+                        <option value="${value}" selected data-tooltip="${tooltip}">${displayLabel}</option>
+                    </select>
+                </div>
+            </div>
+        `;
+        
+        const visionField = html.find('select[name="vision"]').closest('.form-group');
+        if (visionField.length > 0) visionField.before(fieldHtml);
+        else html.find('.talent-test-modifier').append(fieldHtml);
+        
+        modifierContainer = html.find('.modifiers');
+    } else {
+        const select = modifierContainer.find('select[name="situationalModifiers"]');
+        if (select.find(`option:contains("${displayLabel}")`).length === 0) {
+            select.append(`<option value="${value}" selected data-tooltip="${tooltip}">${displayLabel}</option>`);
+        }
+    }
+
+    const select = modifierContainer.find('select[name="situationalModifiers"]');
+
+    select.off('mousedown', 'option').on('mousedown', 'option', function(ev) {
+        ev.preventDefault();
+        const option = $(this);
+        option.prop('selected', !option.prop('selected'));
+        if (typeof targetDialog.rememberFormData === "function") targetDialog.rememberFormData(ev);
+        else html.find('form').trigger('change');
+        return false;
+    });
+
+    if (typeof targetDialog.rememberFormData === "function") targetDialog.rememberFormData();
+}
+
+Hooks.on('dsa5.getRollDialogContextOptions', (dialogState, menuItems) => {
+    const { actor, source, dialog } = dialogState;
+    if (source?.type !== "skill") return;
+
+    const parentDialog = dialog;
+
+    menuItems.push({
+        name: game.i18n.localize("SUPPORTING_TEST.menuLabel"),
+        icon: '<i class="fas fa-hands-helping"></i>',
+        callback: async () => {
+            // --- NEU: Vor dem Öffnen prüfen, ob der Bonus schon im Fenster ist ---
+            const modifierLabel = game.i18n.localize("SUPPORTING_TEST.modifierLabel");
+            if (checkModifierApplied(parentDialog.element, modifierLabel)) {
+                ui.notifications.warn(game.i18n.localize("SUPPORTING_TEST.alreadyApplied"));
+                console.error("DEBUG | Abbruch: Unterstützung bereits vorhanden.");
+                return;
+            }
+
+            const prepare = (l) => l.map(i => ({ id: i.id || i._id, name: i.name })).sort((a, b) => a.name.localeCompare(b.name));
+            const talents = actor.items.filter(i => i.type === "skill");
+            const groups = {
+                body: prepare(talents.filter(i => i.system.group?.value === "body")),
+                social: prepare(talents.filter(i => i.system.group?.value === "social")),
+                nature: prepare(talents.filter(i => i.system.group?.value === "nature")),
+                knowledge: prepare(talents.filter(i => i.system.group?.value === "knowledge")),
+                trade: prepare(talents.filter(i => i.system.group?.value === "trade"))
+            };
+
+            new Dialog({
+                title: game.i18n.localize("SUPPORTING_TEST.title"),
+                content: Handlebars.compile(SUPPORT_TEMPLATE_STRING)({ groups }),
+                buttons: {},
+                render: (html) => {
+                    html.find('.sheet-tabs .item').click(ev => {
+                        const target = ev.currentTarget.dataset.tab;
+                        html.find('.item').removeClass('active');
+                        $(ev.currentTarget).addClass('active');
+                        html.find('.tab').hide();
+                        html.find(`.tab[data-tab="${target}"]`).show();
+                    });
+
+                    html.find('.support-roll-btn').click(async (ev) => {
+                        const skillId = ev.currentTarget.dataset.id;
+                        const skill = actor.items.get(skillId);
+                        
+                        Hooks.once("postProcessDSARoll", (chatOptions, rollData) => {
+                            if (rollData.successLevel > 0) {
+                                const label = game.i18n.localize("SUPPORTING_TEST.modifierLabel");
+                                const tt = `${label}<br>Modifikator: 1<br>Quelle: Unterstützung`;
+                                injectSupportingModifier(parentDialog, "1", tt, `${label} [1]`);
+                                ui.notifications.info(game.i18n.localize("SUPPORTING_TEST.successSuccess"));
+                            }
+                        });
+
+                        actor.setupSkill(skill, {}, "roll").then(setupData => { if(setupData) actor.basicTest(setupData); });
+                        $(ev.currentTarget).closest('.dialog').find('.header-button.close').click();
+                    });
+                }
+            }, { width: 600, resizable: true }).render(true);
+        }
+    });
+});

--- a/macros/skill/Supporting_Talent_Test.js
+++ b/macros/skill/Supporting_Talent_Test.js
@@ -1,11 +1,3 @@
-/**
- * SUPPORTING_CHECK.js
- * Inklusive Überprüfung auf bereits vorhandene Boni.
- */
-
-console.error("%c >>> SUPPORT-SCRIPT: AKTIVIERT (Inkl. Dubletten-Check) <<< ", "background: #800; color: #fff; font-size: 14px;");
-
-// --- NEU: Hilfsfunktion zur Überprüfung des DOM ---
 function checkModifierApplied(dialogHtml, searchString) {
     return $(dialogHtml).find('select[name="situationalModifiers"] option').filter(function() {
         return $(this).text().includes(searchString);

--- a/macros/skill/Supporting_Talent_Test.js
+++ b/macros/skill/Supporting_Talent_Test.js
@@ -1,38 +1,14 @@
-function checkModifierApplied(dialogHtml, searchString) {
-    return $(dialogHtml).find('select[name="situationalModifiers"] option').filter(function() {
-        return $(this).text().includes(searchString);
-    }).length > 0;
+function checkModifierApplied(dialogElement, searchString) {
+    const element = dialogElement[0] || dialogElement;
+    const options = element.querySelectorAll('select[name="situationalModifiers"] option');
+    return Array.from(options).some(opt => opt.textContent.includes(searchString));
 }
 
-const SUPPORT_TEMPLATE_STRING = `
-<div style="margin-bottom: 10px; font-style: italic; font-size: 0.95em; padding: 8px; border-left: 3px solid #7a7971; background: rgba(0,0,0,0.05); line-height: 1.3;">
-    {{localize "SUPPORTING_TEST.description"}}
-</div>
-<nav class="sheet-tabs tabs" data-group="primary" style="display:flex; border-bottom: 1px solid #777; margin-bottom: 10px;">
-    <a class="item active" data-tab="body" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.physical"}}</a>
-    <a class="item" data-tab="social" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.social"}}</a>
-    <a class="item" data-tab="nature" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.nature"}}</a>
-    <a class="item" data-tab="knowledge" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.knowledge"}}</a>
-    <a class="item" data-tab="trade" style="flex:1; text-align:center; padding: 5px; cursor:pointer;">{{localize "SUPPORTING_TEST.groups.trade"}}</a>
-</nav>
-<section class="content supporting-test-content" style="max-height: 400px; overflow-y: auto; padding: 5px;">
-    {{#each groups as |talents groupName|}}
-    <div class="tab {{groupName}} {{#if (eq groupName 'body')}}active{{/if}}" data-tab="{{groupName}}" style="display: {{#if (eq groupName 'body')}}block{{else}}none{{/if}};">
-        <div class="form-group knowledge-buttons" style="display: grid; grid-template-columns: 1fr 1fr; gap: 5px;">
-            {{#each talents}}
-            <button class="support-roll-btn dsa5 button" data-id="{{this.id}}" style="font-size: 1.1em; height: auto; padding: 5px;">{{this.name}}</button>
-            {{/each}}
-        </div>
-    </div>
-    {{/each}}
-</section>
-`;
-
 function injectSupportingModifier(targetDialog, value, tooltip, displayLabel) {
-    const html = $(targetDialog.element);
-    let modifierContainer = html.find('.modifiers');
+    const parentElement = targetDialog.element[0] || targetDialog.element;
+    let modifierContainer = parentElement.querySelector('.modifiers');
 
-    if (modifierContainer.length === 0) {
+    if (!modifierContainer) {
         const finalLabel = game.i18n.localize("situationalModifiers") === "situationalModifiers" ? "Bedingte Modifikatoren" : game.i18n.localize("situationalModifiers");
 
         const fieldHtml = `
@@ -46,30 +22,139 @@ function injectSupportingModifier(targetDialog, value, tooltip, displayLabel) {
             </div>
         `;
         
-        const visionField = html.find('select[name="vision"]').closest('.form-group');
-        if (visionField.length > 0) visionField.before(fieldHtml);
-        else html.find('.talent-test-modifier').append(fieldHtml);
+        const visionField = parentElement.querySelector('select[name="vision"]')?.closest('.form-group');
+        if (visionField) {
+            visionField.insertAdjacentHTML('beforebegin', fieldHtml);
+        } else {
+            parentElement.querySelector('.talent-test-modifier')?.insertAdjacentHTML('beforeend', fieldHtml);
+        }
         
-        modifierContainer = html.find('.modifiers');
+        modifierContainer = parentElement.querySelector('.modifiers');
     } else {
-        const select = modifierContainer.find('select[name="situationalModifiers"]');
-        if (select.find(`option:contains("${displayLabel}")`).length === 0) {
-            select.append(`<option value="${value}" selected data-tooltip="${tooltip}">${displayLabel}</option>`);
+        const select = modifierContainer.querySelector('select[name="situationalModifiers"]');
+        const exists = Array.from(select.options).some(opt => opt.textContent.includes(displayLabel));
+        if (!exists) {
+            select.insertAdjacentHTML('beforeend', `<option value="${value}" selected data-tooltip="${tooltip}">${displayLabel}</option>`);
         }
     }
 
-    const select = modifierContainer.find('select[name="situationalModifiers"]');
+    const select = modifierContainer.querySelector('select[name="situationalModifiers"]');
 
-    select.off('mousedown', 'option').on('mousedown', 'option', function(ev) {
-        ev.preventDefault();
-        const option = $(this);
-        option.prop('selected', !option.prop('selected'));
-        if (typeof targetDialog.rememberFormData === "function") targetDialog.rememberFormData(ev);
-        else html.find('form').trigger('change');
-        return false;
+    select.addEventListener('mousedown', function(ev) {
+        if (ev.target.tagName === 'OPTION') {
+            ev.preventDefault();
+            ev.target.selected = !ev.target.selected;
+            if (typeof targetDialog.rememberFormData === "function") {
+                targetDialog.rememberFormData(ev);
+            } else {
+                const form = parentElement.querySelector('form');
+                if (form) form.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+        }
     });
 
     if (typeof targetDialog.rememberFormData === "function") targetDialog.rememberFormData();
+}
+
+const SUPPORT_TEMPLATE_STRING = `
+<div style="margin-bottom: 10px; font-style: italic; font-size: 0.95em; padding: 8px; background: rgba(0,0,0,0.05); line-height: 1.3;">
+    {{localize "SUPPORTING_TEST.description"}}
+</div>
+<nav class="sheet-tabs tabs" style="display:flex; border-bottom: 1px solid #777; margin-bottom: 10px;">
+    {{#each groups}}
+    <a class="item {{#if this.active}}active{{/if}}" data-action="switchTab" data-tab="{{this.id}}" style="flex:1; text-align:center; padding: 5px; cursor:pointer; font-weight: {{#if this.active}}bold{{else}}normal{{/if}};">{{this.label}}</a>
+    {{/each}}
+</nav>
+<section class="content supporting-test-content" style="max-height: 400px; overflow-y: auto; padding: 5px;">
+    {{#each groups}}
+    <div class="tab {{this.id}} {{#if this.active}}active{{/if}}" style="display: {{#if this.active}}block{{else}}none{{/if}};">
+        <div class="form-group knowledge-buttons" style="display: grid; grid-template-columns: 1fr 1fr; gap: 5px;">
+            {{#each this.talents}}
+            <button type="button" class="support-roll-btn dsa5 button" data-action="rollSupport" data-id="{{this.id}}" style="font-size: 1.1em; height: auto; padding: 5px;">{{this.name}}</button>
+            {{/each}}
+        </div>
+    </div>
+    {{/each}}
+</section>
+`;
+
+const { ApplicationV2 } = foundry.applications.api;
+
+class SupportingTestApp extends ApplicationV2 {
+    static DEFAULT_OPTIONS = {
+        id: "supporting-test-app",
+        window: {
+            resizable: true 
+        },
+        position: {
+            width: 705,
+            height: 575
+        },
+        actions: {
+            switchTab: function(event, target) { this._onSwitchTab(event, target); },
+            rollSupport: function(event, target) { this._onRollSupport(event, target); }
+        }
+    };
+
+    constructor(actor, parentDialog, options) {
+        super(options);
+        this.dsaActor = actor;
+        this.parentDialog = parentDialog;
+        this.activeTab = "body"; 
+    }
+
+    get title() {
+        return game.i18n.localize("SUPPORTING_TEST.title");
+    }
+
+    async _renderHTML(context, options) {
+        const template = Handlebars.compile(SUPPORT_TEMPLATE_STRING);
+        return template(context);
+    }
+
+    _replaceHTML(result, content, options) {
+        content.innerHTML = result;
+    }
+
+    async _prepareContext(options) {
+        const prepare = (l) => l.map(i => ({ id: i.id || i._id, name: i.name })).sort((a, b) => a.name.localeCompare(b.name));
+        const talents = this.dsaActor.items.filter(i => i.type === "skill");
+        
+        return {
+            groups: [
+                { id: "body", label: game.i18n.localize("SKILL.body"), active: this.activeTab === "body", talents: prepare(talents.filter(i => i.system.group?.value === "body")) },
+                { id: "social", label: game.i18n.localize("SKILL.social"), active: this.activeTab === "social", talents: prepare(talents.filter(i => i.system.group?.value === "social")) },
+                { id: "nature", label: game.i18n.localize("SKILL.nature"), active: this.activeTab === "nature", talents: prepare(talents.filter(i => i.system.group?.value === "nature")) },
+                { id: "knowledge", label: game.i18n.localize("SKILL.knowledge"), active: this.activeTab === "knowledge", talents: prepare(talents.filter(i => i.system.group?.value === "knowledge")) },
+                { id: "trade", label: game.i18n.localize("SKILL.trade"), active: this.activeTab === "trade", talents: prepare(talents.filter(i => i.system.group?.value === "trade")) }
+            ]
+        };
+    }
+    
+    _onSwitchTab(event, target) {
+        this.activeTab = target.dataset.tab;
+        this.render(); 
+    }
+
+    async _onRollSupport(event, target) {
+        const skillId = target.dataset.id;
+        const skill = this.dsaActor.items.get(skillId);
+        
+        Hooks.once("postProcessDSARoll", (chatOptions, rollData) => {
+            if (rollData.successLevel > 0) {
+                const label = game.i18n.localize("SUPPORTING_TEST.modifierLabel");
+                const tt = `${label}<br>Modifikator: 1<br>Quelle: Unterstützung`;
+                injectSupportingModifier(this.parentDialog, "1", tt, `${label} [1]`);
+                ui.notifications.info(game.i18n.localize("SUPPORTING_TEST.successSuccess"));
+            }
+        });
+
+        this.dsaActor.setupSkill(skill, {}, "roll").then(setupData => { 
+            if(setupData) this.dsaActor.basicTest(setupData); 
+        });
+        
+        this.close();
+    }
 }
 
 Hooks.on('dsa5.getRollDialogContextOptions', (dialogState, menuItems) => {
@@ -82,54 +167,14 @@ Hooks.on('dsa5.getRollDialogContextOptions', (dialogState, menuItems) => {
         name: game.i18n.localize("SUPPORTING_TEST.menuLabel"),
         icon: '<i class="fas fa-hands-helping"></i>',
         callback: async () => {
-            // Vor dem Öffnen prüfen, ob der Bonus schon im Fenster ist
             const modifierLabel = game.i18n.localize("SUPPORTING_TEST.modifierLabel");
+            
             if (checkModifierApplied(parentDialog.element, modifierLabel)) {
                 ui.notifications.warn(game.i18n.localize("SUPPORTING_TEST.alreadyApplied"));
                 return;
             }
 
-            const prepare = (l) => l.map(i => ({ id: i.id || i._id, name: i.name })).sort((a, b) => a.name.localeCompare(b.name));
-            const talents = actor.items.filter(i => i.type === "skill");
-            const groups = {
-                body: prepare(talents.filter(i => i.system.group?.value === "body")),
-                social: prepare(talents.filter(i => i.system.group?.value === "social")),
-                nature: prepare(talents.filter(i => i.system.group?.value === "nature")),
-                knowledge: prepare(talents.filter(i => i.system.group?.value === "knowledge")),
-                trade: prepare(talents.filter(i => i.system.group?.value === "trade"))
-            };
-
-            new Dialog({
-                title: game.i18n.localize("SUPPORTING_TEST.title"),
-                content: Handlebars.compile(SUPPORT_TEMPLATE_STRING)({ groups }),
-                buttons: {},
-                render: (html) => {
-                    html.find('.sheet-tabs .item').click(ev => {
-                        const target = ev.currentTarget.dataset.tab;
-                        html.find('.item').removeClass('active');
-                        $(ev.currentTarget).addClass('active');
-                        html.find('.tab').hide();
-                        html.find(`.tab[data-tab="${target}"]`).show();
-                    });
-
-                    html.find('.support-roll-btn').click(async (ev) => {
-                        const skillId = ev.currentTarget.dataset.id;
-                        const skill = actor.items.get(skillId);
-                        
-                        Hooks.once("postProcessDSARoll", (chatOptions, rollData) => {
-                            if (rollData.successLevel > 0) {
-                                const label = game.i18n.localize("SUPPORTING_TEST.modifierLabel");
-                                const tt = `${label}<br>Modifikator: 1<br>Quelle: Unterstützung`;
-                                injectSupportingModifier(parentDialog, "1", tt, `${label} [1]`);
-                                ui.notifications.info(game.i18n.localize("SUPPORTING_TEST.successSuccess"));
-                            }
-                        });
-
-                        actor.setupSkill(skill, {}, "roll").then(setupData => { if(setupData) actor.basicTest(setupData); });
-                        $(ev.currentTarget).closest('.dialog').find('.header-button.close').click();
-                    });
-                }
-            }, { width: 600, resizable: true }).render(true);
+            new SupportingTestApp(actor, parentDialog).render(true);
         }
     });
 });


### PR DESCRIPTION
Verwendete Icons:

[fas fa-hands-helping](https://fontawesome.com/icons/handshake-angle?f=classic&s=solid)

Fügt die Bürgermenüoption für [Unterstützende Proben](https://dsa.ulisses-regelwiki.de/grundregeln/einsatz_von_talenten/unterstuetzende-probe.html) hinzu.

CSS:

```
.dsa-skill-grid-3x2 {
    display: grid !important;
    grid-template-columns: repeat(3, 1fr) !important;
    grid-template-rows: repeat(2, auto) !important;
    gap: 5px;
}
```

Folgende Lang-Einträge müssen hinzugefügt werden:

```
"SUPPORTING_TEST": {
        "menuLabel": "Unterstützende Probe",
        "title": "Unterstützendes Talent",
        "description": "Talente können sich gegenseitig unterstützen. Bei diesen Unterstützungen bekommt man immer nur eine Erleichterung von +1 auf die nachfolgende Talentprobe, wenn die vorherige gelungen ist. Der Meister hat das letzte Wort, ob die Erleichterung funktioniert.",
        "modifierLabel": "Unterstützende Probe",
        "successSuccess": "Die unterstützende Probe war erfolgreich. Bonus wurde vermerkt.",
	"alreadyApplied": "Es wurde bereits eine unterstützende Probe für diesen Wurf durchgeführt."
```

```
"SUPPORTING_TEST": {
        "menuLabel": "Supporting Skill Test",
        "title": "Supporting Skill",
        "description": "Skills can support each other. In these cases, you receive a +1 bonus to the subsequent skill check if the previous one was successful. The GM has the final say on whether the bonus applies.",
        "modifierLabel": "Supporting Skill Test",
        "successSuccess": "Supporting test successful. Bonus applied.",
	"alreadyApplied": "A supporting test has already been performed for this roll."
```