### PR TITLE
Witches' Preferred Spells (Aventurian Magic 2)

### DIFF
--- a/macros/witches_preferred_spells.js
+++ b/macros/witches_preferred_spells.js
@@ -1,0 +1,87 @@
+Hooks.once('ready', () => {
+    const DiceDSA5 = game.dsa5.apps.DiceDSA5;
+    const tradName = game.i18n.localize('customWitchTradition');
+
+    const WITCH_MAPPING = {
+        "sisterhoodApe": ["spellAffenhaende", "spellAffenruf", "spellHarmloseGestalt", "spellKraftDesTiers"],
+        "sisterhoodCat": ["spellGrosseGier", "spellHexenkrallen", "spellKatzenaugen", "spellKatzenruf"],
+        "sisterhoodSpider": ["spellHexengalle", "spellKrabbelnderSchrecken", "spellSpinnenlauf", "spellSpinnenruf"],
+        "sisterhoodSnake": ["spellGifthaut", "spellSchlangenruf", "spellSerpentialis", "spellVipernblick"],
+        "sisterhoodSeer": ["spellHexenkrallen", "spellGefunden", "spellKraehenruf", "spellMadasSpiegel"],
+        "sisterhoodToad": ["spellGifthaut", "spellHexenspeichel", "spellKroetensprung", "spellTiereBesprechen"],
+        "sisterhoodOwl": ["spellEulenruf", "spellKatzenaugen", "spellKraftDesTiers", "spellHexenkrallen"]
+    };
+
+    if (DiceDSA5 && DiceDSA5.calculateEnergyCost) {
+        const originalCalculateEnergyCost = DiceDSA5.calculateEnergyCost;
+        
+        DiceDSA5.calculateEnergyCost = async function (isClerical, res, testData) {
+            await originalCalculateEnergyCost.call(this, isClerical, res, testData);
+
+            try {
+                const actor = game.dsa5.apps.DSA5_Utility.getSpeaker(testData?.extra?.speaker);
+                if (!actor || !actor.items.some(i => i.name === tradName)) return;
+
+                const spellName = testData.source?.name;
+                const actorImprints = actor.items.filter(i => i.type === "imprint").map(i => i.name);
+
+                let totalReduction = 0;
+                let foundSisterhoods = [];
+
+                for (const [sKey, spellKeys] of Object.entries(WITCH_MAPPING)) {
+                    const sNameLocalized = game.i18n.localize(sKey);
+                    
+                    if (actorImprints.includes(sNameLocalized)) {
+                        const localizedSpells = spellKeys.map(k => game.i18n.localize(k));
+                        
+                        if (localizedSpells.includes(spellName)) {
+                            totalReduction += 1;
+                            foundSisterhoods.push(sNameLocalized);
+                        }
+                    }
+                }
+
+                if (totalReduction > 0) {
+                    let mods = res.preData?.calculatedSpellModifiers;
+                    if (mods && mods.finalcost > 1) {
+                        mods.finalcost = Math.max(1, mods.finalcost - totalReduction);
+                        
+                        foundSisterhoods.forEach(sName => {
+                            const line = `\n${sName} -1 AsP`;
+                            if (!mods.description.includes(sName)) {
+                                mods.description += line;
+                            }
+                        });
+
+                        if (res.asp !== undefined) res.asp = mods.finalcost;
+                    }
+                }
+            } catch (err) {}
+        };
+    }
+});
+
+Hooks.on('renderDSA5SpellDialog', (app, html, data) => {
+    const dialogData = app.dialogData || data;
+    if (!dialogData?.speaker) return;
+    const actor = game.dsa5.apps.DSA5_Utility.getSpeaker(dialogData.speaker);
+    const tradName = game.i18n.localize('customWitchTradition');
+    if (!actor || !actor.items.some(i => i.name === tradName)) return;
+
+    const $html = $(html);
+    const sitMods = $html.find('[name="situationalModifiers"]');
+    const foreignName = game.i18n.localize('DSASETTINGS.enableForeignSpellModifer');
+    const foreignOption = sitMods.find('option').filter(function() {
+        return $(this).text().includes(foreignName) || $(this).text().includes("Fremdzauber");
+    });
+
+    if (foreignOption.length > 0) {
+        const currentValue = parseInt(foreignOption.val()) || -2;
+        const newValue = currentValue - 2;
+        foreignOption.val(newValue.toString()); 
+        const newText = foreignOption.text().replace(/\[-?\d+\s*\]/, `[${newValue} ]`);
+        foreignOption.text(newText); 
+        foreignOption.attr('data-tooltip', `${foreignName}<br>Modifikator: ${newValue}`);
+        sitMods.trigger('change');
+    }
+});

--- a/macros/witches_preferred_spells.js
+++ b/macros/witches_preferred_spells.js
@@ -1,16 +1,16 @@
+const WITCH_MAPPING = {
+    "sisterhoodApe": ["spellAffenhaende", "spellAffenruf", "spellHarmloseGestalt", "spellKraftDesTiers"],
+    "sisterhoodCat": ["spellGrosseGier", "spellHexenkrallen", "spellKatzenaugen", "spellKatzenruf"],
+    "sisterhoodSpider": ["spellHexengalle", "spellKrabbelnderSchrecken", "spellSpinnenlauf", "spellSpinnenruf"],
+    "sisterhoodSnake": ["spellGifthaut", "spellSchlangenruf", "spellSerpentialis", "spellVipernblick"],
+    "sisterhoodSeer": ["spellHexenkrallen", "spellGefunden", "spellKraehenruf", "spellMadasSpiegel"],
+    "sisterhoodToad": ["spellGifthaut", "spellHexenspeichel", "spellKroetensprung", "spellTiereBesprechen"],
+    "sisterhoodOwl": ["spellEulenruf", "spellKatzenaugen", "spellKraftDesTiers", "spellHexenkrallen"]
+};
+
 Hooks.once('ready', () => {
     const DiceDSA5 = game.dsa5.apps.DiceDSA5;
     const tradName = game.i18n.localize('customWitchTradition'); // der übliche lang key hat bei mir warum auch immer nicht geklappt
-
-    const WITCH_MAPPING = {
-        "sisterhoodApe": ["spellAffenhaende", "spellAffenruf", "spellHarmloseGestalt", "spellKraftDesTiers"],
-        "sisterhoodCat": ["spellGrosseGier", "spellHexenkrallen", "spellKatzenaugen", "spellKatzenruf"],
-        "sisterhoodSpider": ["spellHexengalle", "spellKrabbelnderSchrecken", "spellSpinnenlauf", "spellSpinnenruf"],
-        "sisterhoodSnake": ["spellGifthaut", "spellSchlangenruf", "spellSerpentialis", "spellVipernblick"],
-        "sisterhoodSeer": ["spellHexenkrallen", "spellGefunden", "spellKraehenruf", "spellMadasSpiegel"],
-        "sisterhoodToad": ["spellGifthaut", "spellHexenspeichel", "spellKroetensprung", "spellTiereBesprechen"],
-        "sisterhoodOwl": ["spellEulenruf", "spellKatzenaugen", "spellKraftDesTiers", "spellHexenkrallen"]
-    };
 
     if (DiceDSA5 && DiceDSA5.calculateEnergyCost) {
         const originalCalculateEnergyCost = DiceDSA5.calculateEnergyCost;
@@ -72,16 +72,6 @@ Hooks.on('renderDSA5SpellDialog', (app, html, data) => {
     const spellName = dialogData.source?.name;
     const actorImprints = actor.items.filter(i => i.type === "imprint").map(i => i.name);
 
-    const WITCH_MAPPING = {
-        "sisterhoodApe": ["spellAffenhaende", "spellAffenruf", "spellHarmloseGestalt", "spellKraftDesTiers"],
-        "sisterhoodCat": ["spellGrosseGier", "spellHexenkrallen", "spellKatzenaugen", "spellKatzenruf"],
-        "sisterhoodSpider": ["spellHexengalle", "spellKrabbelnderSchrecken", "spellSpinnenlauf", "spellSpinnenruf"],
-        "sisterhoodSnake": ["spellGifthaut", "spellSchlangenruf", "spellSerpentialis", "spellVipernblick"],
-        "sisterhoodSeer": ["spellHexenkrallen", "spellGefunden", "spellKraehenruf", "spellMadasSpiegel"],
-        "sisterhoodToad": ["spellGifthaut", "spellHexenspeichel", "spellKroetensprung", "spellTiereBesprechen"],
-        "sisterhoodOwl": ["spellEulenruf", "spellKatzenaugen", "spellKraftDesTiers", "spellHexenkrallen"]
-    };
-
     let isPreferred = false;
     for (const [sKey, spellKeys] of Object.entries(WITCH_MAPPING)) {
         if (actorImprints.includes(game.i18n.localize(sKey))) {
@@ -97,7 +87,6 @@ Hooks.on('renderDSA5SpellDialog', (app, html, data) => {
         const maxModsElement = $html.find('.maxMods');
         const newMax = (parseInt(maxModsElement.text()) || 0) + 1;
         maxModsElement.text(newMax);
-        maxModsElement.css('color', 'green');
     }
 
     const sitMods = $html.find('[name="situationalModifiers"]');

--- a/macros/witches_preferred_spells.js
+++ b/macros/witches_preferred_spells.js
@@ -1,6 +1,6 @@
 Hooks.once('ready', () => {
     const DiceDSA5 = game.dsa5.apps.DiceDSA5;
-    const tradName = game.i18n.localize('customWitchTradition');
+    const tradName = game.i18n.localize('customWitchTradition'); // der übliche lang key hat bei mir warum auch immer nicht geklappt
 
     const WITCH_MAPPING = {
         "sisterhoodApe": ["spellAffenhaende", "spellAffenruf", "spellHarmloseGestalt", "spellKraftDesTiers"],
@@ -69,6 +69,37 @@ Hooks.on('renderDSA5SpellDialog', (app, html, data) => {
     if (!actor || !actor.items.some(i => i.name === tradName)) return;
 
     const $html = $(html);
+    const spellName = dialogData.source?.name;
+    const actorImprints = actor.items.filter(i => i.type === "imprint").map(i => i.name);
+
+    const WITCH_MAPPING = {
+        "sisterhoodApe": ["spellAffenhaende", "spellAffenruf", "spellHarmloseGestalt", "spellKraftDesTiers"],
+        "sisterhoodCat": ["spellGrosseGier", "spellHexenkrallen", "spellKatzenaugen", "spellKatzenruf"],
+        "sisterhoodSpider": ["spellHexengalle", "spellKrabbelnderSchrecken", "spellSpinnenlauf", "spellSpinnenruf"],
+        "sisterhoodSnake": ["spellGifthaut", "spellSchlangenruf", "spellSerpentialis", "spellVipernblick"],
+        "sisterhoodSeer": ["spellHexenkrallen", "spellGefunden", "spellKraehenruf", "spellMadasSpiegel"],
+        "sisterhoodToad": ["spellGifthaut", "spellHexenspeichel", "spellKroetensprung", "spellTiereBesprechen"],
+        "sisterhoodOwl": ["spellEulenruf", "spellKatzenaugen", "spellKraftDesTiers", "spellHexenkrallen"]
+    };
+
+    let isPreferred = false;
+    for (const [sKey, spellKeys] of Object.entries(WITCH_MAPPING)) {
+        if (actorImprints.includes(game.i18n.localize(sKey))) {
+            const localizedSpells = spellKeys.map(k => game.i18n.localize(k));
+            if (localizedSpells.includes(spellName)) {
+                isPreferred = true;
+                break;
+            }
+        }
+    }
+
+    if (isPreferred) {
+        const maxModsElement = $html.find('.maxMods');
+        const newMax = (parseInt(maxModsElement.text()) || 0) + 1;
+        maxModsElement.text(newMax);
+        maxModsElement.css('color', 'green');
+    }
+
     const sitMods = $html.find('[name="situationalModifiers"]');
     const foreignName = game.i18n.localize('DSASETTINGS.enableForeignSpellModifer');
     const foreignOption = sitMods.find('option').filter(function() {


### PR DESCRIPTION
Umsetzung der Optionalen Regel [Zaubervorlieben der Hexen](https://dsa.ulisses-regelwiki.de/hnhjmhng.html).

Orientiert sich an Kraftkontrolle wenn Prägung übereinstimmt -stackt mit dem neuen aktiven effekt für fremdtraditionen.

Anzahl der Zaubermods ist auch drinn, vlt fehlt noch eine an und aus checkbox? Es beschwert sich sonst bestimmt wieder jmd über mehr content....

```
{
  "customWitchTradition": "Tradition (Hexen)",
  "sisterhoodSnake": "Schwester des Wissens",
  "sisterhoodSeer": "Seherin von Heute und Morgen",
  "sisterhoodApe": "Fahrende Schwester",
  "sisterhoodCat": "Schöne der Nacht",
  "sisterhoodSpider": "Schwarze Witwe",
  "sisterhoodToad": "Tochter der Erde",
  "sisterhoodOwl": "Verschwiegene Schwester",
  "spellHexenkrallen": "Hexenkrallen",
  "spellGefunden": "Gefunden",
  "spellKraehenruf": "Krähenruf",
  "spellMadasSpiegel": "Madas Spiegel",
  "spellAffenhaende": "Affenhände",
  "spellAffenruf": "Affenruf",
  "spellHarmloseGestalt": "Harmlose Gestalt",
  "spellKraftDesTiers": "Kraft des Tieres",
  "spellGrosseGier": "Große Gier",
  "spellKatzenaugen": "Katzenaugen",
  "spellKatzenruf": "Katzenruf",
  "spellHexengalle": "Hexengalle",
  "spellKrabbelnderSchrecken": "Krabbelnder Schrecken",
  "spellSpinnenlauf": "Spinnenlauf",
  "spellSpinnenruf": "Spinnenruf",
  "spellGifthaut": "Gifthaut",
  "spellSchlangenruf": "Schlangenruf",
  "spellSerpentialis": "Serpentialis",
  "spellVipernblick": "Vipernblick",
  "spellHexenspeichel": "Hexenspeichel",
  "spellKroetensprung": "Krötensprung",
  "spellTiereBesprechen": "Tiere besprechen",
  "spellEulenruf": "Eulenruf"
}
```

```
{
  "customWitchTradition": "Tradition (Witches)",
  "sisterhoodSnake": "Sister of Knowledge",
  "sisterhoodSeer": "Seer of Today and Tomorrow",
  "sisterhoodApe": "Traveling Sister",
  "sisterhoodCat": "Beauty of the Night",
  "sisterhoodSpider": "Black Widow",
  "sisterhoodToad": "Daughter of the Earth",
  "sisterhoodOwl": "Secretive Sister",
  "spellHexenkrallen": "Witch's Claws",
  "spellGefunden": "Found",
  "spellKraehenruf": "Call of the Crows",
  "spellMadasSpiegel": "Mada's Mirror",
  "spellAffenhaende": "Monkey's Hands",
  "spellAffenruf": "Call of the Monkeys",
  "spellHarmloseGestalt": "Harmless Form",
  "spellKraftDesTiers": "Animal Power",
  "spellGrosseGier": "Great Greed",
  "spellKatzenaugen": "Cat's Eyes",
  "spellKatzenruf": "Call of the Cats",
  "spellHexengalle": "Witch's Bile",
  "spellKrabbelnderSchrecken": "Crawling Horror",
  "spellSpinnenlauf": "Spider's Walk",
  "spellSpinnenruf": "Call of the Spiders",
  "spellGifthaut": "Poisonous Skin",
  "spellSchlangenruf": "Call of the Snakes",
  "spellSerpentialis": "Serpentialis",
  "spellVipernblick": "Viper's Gaze",
  "spellHexenspeichel": "Witch's Saliva",
  "spellKroetensprung": "Toad's Leap",
  "spellTiereBesprechen": "Talking to Animals",
  "spellEulenruf": "Call of the Owls"
}
```

EN ist deepl-Platzhalter