### PR TITLE
Ratten: Panik vor Feuer (Hiddendeep + Dragon knight)

### DIFF
--- a/macros/specialability/Ratte_PanikvorFeuer.js
+++ b/macros/specialability/Ratte_PanikvorFeuer.js
@@ -4,11 +4,11 @@ const lang = game.i18n.lang === "de" ? "de" : "en";
 const dict = {
     de: {
         title: "Ratte - Angst vor Feuer",
-        panicText: "Panik vor Feuer: Wenn Riesenratten mit einer größeren Menge von Feuer konfrontiert werden (etwa Fackelgröße), fliehen sie bei 1–3 auf 1W6."
+        panicText: "Panik vor Feuer: Wenn Ratten mit einer größeren Menge von Feuer konfrontiert werden (etwa Fackelgröße), fliehen sie bei 1–3 auf 1W6."
     },
     en: {
         title: "Rat - Fear of Fire",
-        panicText: "Panic from Fire: When giant rats are confronted with a larger amount of fire (about torch size), they flee on a 1-3 on 1d6."
+        panicText: "Panic from Fire: When rats are confronted with a larger amount of fire (about torch size), they flee on a 1-3 on 1d6."
     }
 }[lang];
 

--- a/macros/specialability/Ratte_PanikvorFeuer.js
+++ b/macros/specialability/Ratte_PanikvorFeuer.js
@@ -1,0 +1,58 @@
+// This is a system macro used for automation. It is disfunctional without the proper context.
+
+const lang = game.i18n.lang === "de" ? "de" : "en";
+const dict = {
+    de: {
+        title: "Ratte - Angst vor Feuer",
+        panicText: "Panik vor Feuer: Wenn Riesenratten mit einer größeren Menge von Feuer konfrontiert werden (etwa Fackelgröße), fliehen sie bei 1–3 auf 1W6."
+    },
+    en: {
+        title: "Rat - Fear of Fire",
+        panicText: "Panic from Fire: When giant rats are confronted with a larger amount of fire (about torch size), they flee on a 1-3 on 1d6."
+    }
+}[lang];
+
+if (typeof testData === "undefined" || !testData) return;
+if (testData.mode !== "attack") return;
+
+function hasActiveTorch(targetActor) {
+    if (!targetActor) return false;
+    const torchItems = targetActor.items.filter(item => {
+        const onUse = item.flags?.dsa5?.onUseEffect || "";
+        return onUse.includes('applyVisionOrLight(true, "torch"');
+    });
+    if (torchItems.length === 0) return false;
+    return torchItems.some(torchItem => targetActor.effects.some(e => e.name === torchItem.name));
+}
+
+const targets = Array.from(game.user.targets);
+if (targets.length === 0) return;
+
+const targetHasTorch = targets.some(t => hasActiveTorch(t.actor));
+if (!targetHasTorch) return;
+
+const app = data?.dialogState?.dialog;
+if (app) {
+    if (app._ratFearRolled) return;
+    app._ratFearRolled = true;
+}
+
+(async () => {
+    const roll = await new Roll("1d6").evaluate();
+    
+    await roll.toMessage({
+        speaker: ChatMessage.getSpeaker(),
+        flavor: `<b>${dict.title}</b>`
+    });
+
+    if (roll.total <= 3) {
+        ChatMessage.create({
+            speaker: ChatMessage.getSpeaker(),
+            content: `<div>
+                        <b>${dict.title}</b><br>
+                        <i>${dict.panicText}</i>
+                      </div>`,
+            whisper: ChatMessage.getWhisperRecipients("GM")
+        });
+    }
+})();


### PR DESCRIPTION
Der aktive Effekt "Panik vor Feuer" (Teil der [Regeln](https://dsa.ulisses-regelwiki.de/Ratte.html) für Ratten und Riesenratten)
<img width="565" height="51" alt="grafik" src="https://github.com/user-attachments/assets/1dabbf0e-cea1-4e6f-a1dc-5142e2ad81a2" />

prüft bei einer Angriffsprobe, ob das Ziel über eine aktive Fackel verfügt. Wenn ja, wird ein 1d6 gewürfelt. Ist das Ergebnis 3 oder niedriger, wird eine Nachricht an die SL geschickt, dass die Ratte fliehen könnte/sollte.

Ich denke eine Überprüfung pro Runde seitens der Ratten reicht, man könnte auch einen ähnlichen Effekt auf Ratten-angreifende Akteuer anwenden, aber ich denke das wird irgentwann zuviel Spam.