### PR TITLE
Armor Care Kit (Armory 1)

### DIFF
--- a/macros/items/armor_care_kit.js
+++ b/macros/items/armor_care_kit.js
@@ -6,6 +6,8 @@ const dict = {
         desc: "Mit einem Rüstungspflegeset kann ein Held die erste Stufe Beschädigung einer Rüstung aufheben. Er muss dazu eine Probe auf das Herstellungstalent ablegen (erschwert um die Belastung).",
         metalworking: "Metallbearbeitung",
         woodworking: "Holzbearbeitung",
+        leatherworking: "Lederbearbeitung",
+        clothworking: "Stoffbearbeitung",
         title: "Rüstungspflegeset",
         noArmors: "Keine reparierbaren Rüstungen gefunden.",
         selectArmor: "Bitte wähle zuerst eine Rüstung aus.",
@@ -18,6 +20,8 @@ const dict = {
         desc: "With an armor care kit, you can remove the first level of damage. You must make a crafting talent check (penalized by encumbrance).",
         metalworking: "Metalworking",
         woodworking: "Woodworking",
+        leatherworking: "Leatherworking",
+        clothworking: "Clothworking",
         title: "Armor Care Kit",
         noArmors: "No repairable armors found.",
         selectArmor: "Please select an armor first.",
@@ -95,6 +99,14 @@ class ArmorCareApp extends foundry.applications.api.ApplicationV2 {
                     </button>
                     <button class="col two dsa5 button" data-action="repair" data-skill="${dict.woodworking}" ${!this.selectedArmorId ? 'disabled' : ''}>
                         <i class="fas fa-tree"></i> ${dict.woodworking}
+                    </button>
+                </div>
+                <div class="row-section gap5px margin-top">
+                    <button class="col two dsa5 button" data-action="repair" data-skill="${dict.leatherworking}" ${!this.selectedArmorId ? 'disabled' : ''}>
+                        <i class="fas fa-boot"></i> ${dict.leatherworking}
+                    </button>
+                    <button class="col two dsa5 button" data-action="repair" data-skill="${dict.clothworking}" ${!this.selectedArmorId ? 'disabled' : ''}>
+                        <i class="fas fa-cut"></i> ${dict.clothworking}
                     </button>
                 </div>
             </div>

--- a/macros/items/armor_care_kit.js
+++ b/macros/items/armor_care_kit.js
@@ -1,0 +1,172 @@
+// This is a system macro used for automation. It is disfunctional without the proper context.
+
+const lang = game.i18n.lang == "de" ? "de" : "en";
+const dict = {
+    de: {
+        desc: "Mit einem Rüstungspflegeset kann ein Held die erste Stufe Beschädigung einer Rüstung aufheben. Er muss dazu eine Probe auf das Herstellungstalent ablegen (erschwert um die Belastung).",
+        metalworking: "Metallbearbeitung",
+        woodworking: "Holzbearbeitung",
+        title: "Rüstungspflegeset",
+        noArmors: "Keine reparierbaren Rüstungen gefunden.",
+        selectArmor: "Bitte wähle zuerst eine Rüstung aus.",
+        success: (name) => `${name} wurde erfolgreich repariert!`,
+        fail: (name) => `Die Reparatur von ${name} ist fehlgeschlagen.`,
+        noActor: "Kein Actor gefunden.",
+        noSkill: (name) => `Talent "${name}" nicht gefunden.`
+    },
+    en: {
+        desc: "With an armor care kit, you can remove the first level of damage. You must make a crafting talent check (penalized by encumbrance).",
+        metalworking: "Metalworking",
+        woodworking: "Woodworking",
+        title: "Armor Care Kit",
+        noArmors: "No repairable armors found.",
+        selectArmor: "Please select an armor first.",
+        success: (name) => `${name} was successfully repaired!`,
+        fail: (name) => `Repair of ${name} failed.`,
+        noActor: "No actor found.",
+        noSkill: (name) => `Skill "${name}" not found.`
+    }
+}[lang];
+
+if (!actor) return ui.notifications.warn(dict.noActor);
+
+class ArmorCareApp extends foundry.applications.api.ApplicationV2 {
+    static DEFAULT_OPTIONS = {
+        id: "armor-care-app",
+        classes: ["dsa5"],
+        window: { title: dict.title, resizable: true },
+        position: { width: 420, height: "auto" },
+        actions: {
+            selectArmor: function(event, target) { this._onSelectArmor(event, target); },
+            repair: function(event, target) { this._onRepair(event, target); }
+        }
+    };
+
+    constructor(options) {
+        super(options);
+        this.selectedArmorId = null;
+    }
+
+    async _prepareContext() {
+        const eligibleArmors = actor.items.filter(i => {
+            if (i.type !== "armor") return false;
+            const max = foundry.utils.getProperty(i, "system.structure.max");
+            const val = foundry.utils.getProperty(i, "system.structure.value");
+            if (!max || max <= 0 || val === undefined) return false;
+            const ratio = val / max;
+            if (ratio >= 1.0) return false;
+            return max <= 4 ? ratio > 0.65 : ratio >= 0.8;
+        });
+
+        return { armors: eligibleArmors, hasArmors: eligibleArmors.length > 0 };
+    }
+
+    async _renderHTML(context, options) {
+        if (!context.hasArmors) {
+            return `<div class="paddingBox center"><i>${dict.noArmors}</i></div>`;
+        }
+
+        const armorHtml = context.armors.map(a => {
+            const isSelected = this.selectedArmorId === a.id;
+            const enc = foundry.utils.getProperty(a, "system.encumbrance.value") || 0;
+            return `
+            <li>
+                <label data-action="selectArmor" data-id="${a.id}">
+                    <input type="radio" name="armorChoice" value="${a.id}" ${isSelected ? 'checked' : ''} />
+                    <img src="${a.img}" width="40" height="40" class="dsa-card-icon-img"/>
+                    <span>${a.name} (BE: ${enc})</span>
+                </label>
+            </li>`;
+        }).join("");
+
+        return `
+            <div class="marginBottom">
+                <p class="center"><i>${dict.desc}</i></p>
+                
+                <div class="dsa-card-list thinscroll dsa-card-scroll-box">
+                    <ul>
+                        ${armorHtml}
+                    </ul>
+                </div>
+
+                <div class="row-section gap5px margin-top">
+                    <button class="col two dsa5 button" data-action="repair" data-skill="${dict.metalworking}" ${!this.selectedArmorId ? 'disabled' : ''}>
+                        <i class="fas fa-hammer"></i> ${dict.metalworking}
+                    </button>
+                    <button class="col two dsa5 button" data-action="repair" data-skill="${dict.woodworking}" ${!this.selectedArmorId ? 'disabled' : ''}>
+                        <i class="fas fa-tree"></i> ${dict.woodworking}
+                    </button>
+                </div>
+            </div>
+        `;
+    }
+
+    _replaceHTML(result, content, options) {
+        content.innerHTML = result;
+    }
+
+    _onSelectArmor(event, target) {
+        const id = target.dataset.id;
+        this.selectedArmorId = (this.selectedArmorId === id) ? null : id;
+        this.render(); 
+    }
+
+    async _onRepair(event, target) {
+        target.disabled = true; 
+        await this.executeRepair(target.dataset.skill);
+    }
+
+    async executeRepair(skillName) {
+        if (!this.selectedArmorId) return ui.notifications.warn(dict.selectArmor);
+
+        const skill = actor.items.find(i => i.type === "skill" && i.name === skillName);
+        if (!skill) return ui.notifications.error(dict.noSkill(skillName));
+
+        try {
+            const tokenId = actor.getActiveTokens()[0]?.id || "";
+            const armor = actor.items.get(this.selectedArmorId);
+            if (!armor) return;
+
+            const encumbrance = foundry.utils.getProperty(armor, "system.encumbrance.value") || 0;
+            const modifier = -Math.abs(encumbrance);
+
+            const setupData = await actor.setupSkill(skill.toObject(), { modifier }, tokenId);
+            
+            const testResult = await actor.basicTest(setupData);
+            const successLevel = testResult?.result?.successLevel ?? 0;
+            
+            if (successLevel > 0) {
+                await actor.updateEmbeddedDocuments("Item", [{
+                    _id: armor.id,
+                    "system.structure.value": armor.system.structure.max
+                }]);
+                
+                ui.notifications.info(dict.success(armor.name));
+                this.selectedArmorId = null;
+                
+                const remainingArmors = actor.items.filter(i => {
+                    if (i.type !== "armor") return false;
+                    const max = foundry.utils.getProperty(i, "system.structure.max");
+                    const val = foundry.utils.getProperty(i, "system.structure.value");
+                    if (!max || max <= 0 || val === undefined) return false;
+                    const ratio = val / max;
+                    if (ratio >= 1.0) return false;
+                    return max <= 4 ? ratio > 0.65 : ratio >= 0.8;
+                });
+
+                if (remainingArmors.length === 0) {
+                    this.close();
+                } else {
+                    this.render();
+                }
+
+            } else {
+                ui.notifications.warn(dict.fail(armor.name));
+            }
+        } catch (err) {
+            console.warn("Rüstungspflege: Fehler bei der Probe.", err);
+        }
+    }
+}
+
+new ArmorCareApp().render(true);


### PR DESCRIPTION
Benutzt Icons:

[fas fa-hammer](https://fontawesome.com/icons/hammer?f=classic&s=solid)
[fas fa-tree](https://fontawesome.com/icons/tree?s=solid)


Automatisiert das [Rüstungspflegeset](https://dsa.ulisses-regelwiki.de/ruestungspflegeset.html).

Sollte folgende Itembeschreibung beinhalten:

> Regel: Das Rüstungspflegeset hat nur einen regeltechnischen Effekt, wenn du mit Rüstungsstabilität spielst. Mit einem Rüstungspflegeset kann ein Held die erste Stufe Verschleiß einer Rüstung aufheben. Er muss dazu nicht die Fähigkeit besitzen, die Rüstung herstellen zu können, aber er muss eine Probe auf das Herstellungstalent, beispielsweise Metall- oder Holzbearbeitung, ablegen. Die Probe ist um die BE der Rüstung erschwert. Gelingt die Probe, so wird die Verschleißstufe aufgehoben. Sollte die Rüstung mehr als nur 1 Stufe Verschleiß aufweisen, kann der Held nicht von der Wirkung des Rüstungspflegesets profitieren. Für jede Rüstungsart, also beispielsweise Lederrüstungen oder Kettenrüstungen, existiert ein eigenes Pflegeset.